### PR TITLE
Subclass fixes for torchbench

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -832,11 +832,12 @@ class TestSubclass(unittest.TestCase):
         for groupsize in [256, 128]:
             for inner_k_tiles in [8, 2]:
                 for m in [1, 256]:
-                    self._test_dequantize_impl(
-                        lambda w: Int4WeightOnlyQuantizedLinearWeight.from_float(w, groupsize, inner_k_tiles),
-                        15,
-                        test_shape=[m, 256, 8]
-                    )
+                    for n in [8, 13]:
+                        self._test_dequantize_impl(
+                            lambda w: Int4WeightOnlyQuantizedLinearWeight.from_float(w, groupsize, inner_k_tiles),
+                            15,
+                            test_shape=[m, 256, n]
+                        )
 
     def _test_lin_weight_subclass_impl(
         self,
@@ -886,11 +887,12 @@ class TestSubclass(unittest.TestCase):
         for groupsize in [128, 64]:
             for inner_k_tiles in [4, 2]:
                 for m in [1, 256]:
-                    self._test_lin_weight_subclass_impl(
-                        lambda w: Int4WeightOnlyQuantizedLinearWeight.from_float(w, groupsize, inner_k_tiles),
-                        10,
-                        test_shape=[m, 256, 8]
-                    )
+                    for n in [8, 13]:
+                        self._test_lin_weight_subclass_impl(
+                            lambda w: Int4WeightOnlyQuantizedLinearWeight.from_float(w, groupsize, inner_k_tiles),
+                            10,
+                            test_shape=[m, 256, n]
+                        )
 
     @torch.no_grad()
     def _test_lin_weight_subclass_api_impl(

--- a/torchao/quantization/quant_primitives.py
+++ b/torchao/quantization/quant_primitives.py
@@ -168,10 +168,7 @@ def dynamically_quantize_per_channel(x, quant_min, quant_max, target_dtype):
     eps = torch.finfo(torch.float32).eps
 
     # get min and max
-    try:
-        min_val, max_val = torch.aminmax(x, dim=1)
-    except:
-        breakpoint()
+    min_val, max_val = torch.aminmax(x, dim=1)
 
     # calculate scale and zero point based on min and max
     # reference: https://fburl.com/code/srbiybme
@@ -354,9 +351,6 @@ def quant_int8_per_token_matmul(
     assert (
         w_vals_int8_t.dtype == torch.int8
     ), f"w dtype {w_vals_int8_t.dtype} not yet supported"
-    # assert (
-    #     w_scales.dtype == output_dtype
-    # ), f"{w_scales.dtype} does not match {output_dtype}"
 
     #
     # 1. do the matrix form of dot(X_i, W_j)

--- a/torchao/quantization/quant_primitives.py
+++ b/torchao/quantization/quant_primitives.py
@@ -168,7 +168,10 @@ def dynamically_quantize_per_channel(x, quant_min, quant_max, target_dtype):
     eps = torch.finfo(torch.float32).eps
 
     # get min and max
-    min_val, max_val = torch.aminmax(x, dim=1)
+    try:
+        min_val, max_val = torch.aminmax(x, dim=1)
+    except:
+        breakpoint()
 
     # calculate scale and zero point based on min and max
     # reference: https://fburl.com/code/srbiybme
@@ -351,9 +354,9 @@ def quant_int8_per_token_matmul(
     assert (
         w_vals_int8_t.dtype == torch.int8
     ), f"w dtype {w_vals_int8_t.dtype} not yet supported"
-    assert (
-        w_scales.dtype == output_dtype
-    ), f"{w_scales.dtype} does not match {output_dtype}"
+    # assert (
+    #     w_scales.dtype == output_dtype
+    # ), f"{w_scales.dtype} does not match {output_dtype}"
 
     #
     # 1. do the matrix form of dot(X_i, W_j)
@@ -375,8 +378,8 @@ def quant_int8_per_token_matmul(
         torch.bfloat16,
     ], f"x_scales needs to be a torch.float32 or torch.bfloat16 but got {x_scales.dtype}"
 
-    y = (y_dot_int32 * x_scales.view(-1, 1) * w_scales).reshape(
-        *x_vals_int8.shape[:-1], -1
+    y = (y_dot_int32 * x_scales.reshape(-1, 1) * w_scales).reshape(
+        *x_vals_int8.shape[:-1], y_dot_int32.shape[-1]
     )
 
     # can downcast only at the very end


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #24

Summary:

pytorch update changed flatten, now updated. Handle a number of
behaviors needed to work with torchbench dynamo userbenchmark.
Removed transpose and detach code and broke them into _change_shape and
_apply_fn_to_data methods, changed subclasses to overwrite
torch_function for torch.nn.functional.linear rather than mm and addmm
individually since linear can also hit expand, view, bmm...etc.

Test Plan: python test/test.py

Reviewers:

Subscribers:

Tasks:

Tags: