### PR TITLE
smoothquant fixes

### DIFF
--- a/torchao/quantization/smoothquant.py
+++ b/torchao/quantization/smoothquant.py
@@ -199,6 +199,7 @@ class SmoothFakeDynamicallyQuantizedLinear(SmoothFakeDynQuantMixin, torch.nn.Lin
 
 source_cls_to_target_cls = {
     torch.nn.Linear: SmoothFakeDynamicallyQuantizedLinear,
+    torch.nn.modules.linear.NonDynamicallyQuantizableLinear: SmoothFakeDynamicallyQuantizedLinear,
 }
 
 
@@ -212,8 +213,8 @@ def swap_linear_with_smooth_fq_linear(
             new_fqn = name
         else:
             new_fqn = f"{cur_fqn}.{name}"
-        if ((skip_fqn_list is None) or (new_fqn not in skip_fqn_list)) and isinstance(
-            child, tuple(source_cls_to_target_cls.keys())
+        if ((skip_fqn_list is None) or (new_fqn not in skip_fqn_list)) and (
+            type(child) in source_cls_to_target_cls.keys()
         ):
             target_cls = source_cls_to_target_cls[type(child)]
             new_child = target_cls.from_float(child, alpha=alpha)

--- a/torchao/quantization/smoothquant.py
+++ b/torchao/quantization/smoothquant.py
@@ -137,7 +137,7 @@ class SmoothFakeDynamicallyQuantizedLinear(SmoothFakeDynQuantMixin, torch.nn.Lin
         super().__init__(*args, **kwargs)
         self.init_smoothquant_variables(alpha)
 
-    def forward(self, X):
+    def forward(self, X, *args, **kwargs):
         if self.calibrating:
             self.update_x_running_abs_max(X)
             Y = F.linear(X, self.weight, self.bias)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #28

Summary: certain custom linear modules add additional inputs to the
forward that need to be handled but can be otherwise ignored.
Additionally swap_linear_with_smooth_fq_linear had a bug where linear
subclasses would get past the if statement and error on the dict key
lookup since the actual class wasn't expected.
(https://github.com/pytorch-labs/ao/issues/30) enabled
NonDynamicallyQuantizableLinear to work with smoothquant and fixed bug
for other subclasses. At some point this should be brought in line with
the other APIs if its getting use.

Test Plan: python test/test.py

Reviewers:

Subscribers:

Tasks:

Tags: