### PR TITLE
Move some quantization ops to pytorch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 torch
 numpy
 sentencepiece
+packaging

--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -23,9 +23,9 @@ from torchao.quantization.quant_api import apply_dynamic_quant
 from torchao.quantization.quant_api import (
     Quantizer,
     TwoStepQuantizer,
-    Int8DynActInt4WeightGPTQQuantizer,
-    Int8DynActInt4WeightQuantizer,
-    Int8DynActInt4WeightLinear,
+)
+from torchao.quantization.utils import (
+    TORCH_VERSION_AFTER_2_4,
 )
 from pathlib import Path
 from sentencepiece import SentencePieceProcessor
@@ -136,7 +136,11 @@ class TestQuantFlow(unittest.TestCase):
         compiled = m(*example_inputs)
         torch.testing.assert_close(quantized, compiled, atol=0, rtol=0)
 
+    @unittest.skipIf(not TORCH_VERSION_AFTER_2_4, "skipping when torch verion is 2.3 or lower")
     def test_8da4w_quantizer(self):
+        from torchao.quantization.quant_api import Int8DynActInt4WeightQuantizer
+        from torchao.quantization.quant_api import Int8DynActInt4WeightLinear
+
         quantizer = Int8DynActInt4WeightQuantizer(group_size=32)
         m = M().eval()
         example_inputs = m.example_inputs()
@@ -147,6 +151,7 @@ class TestQuantFlow(unittest.TestCase):
 
     @unittest.skip("skipping until we get checkpoints for gpt-fast")
     def test_gptq_quantizer(self):
+        from torchao.quantization.quant_api import Int8DynActInt4WeightGPTQQuantizer
         # should be similar to TorchCompileDynamicQuantizer
         precision = torch.bfloat16
         device = "cpu"
@@ -163,8 +168,8 @@ class TestQuantFlow(unittest.TestCase):
         blocksize = 128
         percdamp = 0.01
         groupsize = 128
-        calibration_tasks = ["hellaswag"]
-        calibration_limit = 200 # 1000
+        calibration_tasks = ["wikitext"]
+        calibration_limit = 5
         calibration_seq_length = 100
         pad_calibration_inputs = False
         quantizer = Int8DynActInt4WeightGPTQQuantizer(

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -23,11 +23,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from .dynamic_quant import DynamicallyPerAxisQuantizedLinear
-from .quant_primitives import (
-    get_group_qparams_symmetric,
-    group_quantize_tensor_symmetric,
-    per_token_dynamic_quant,
-)
+from .utils import TORCH_VERSION_AFTER_2_4
+
 from .subclass import (
     Int4WeightOnlyQuantizedLinearWeight,
     Int8DynamicallyQuantizedLinearWeight,
@@ -35,6 +32,12 @@ from .subclass import (
     QuantizedLinearWeightBase,
 )
 from .weight_only import WeightOnlyInt8QuantLinear
+
+_AFTER_TORCH_2_4_ONLY = [
+    "Int8DynActInt4WeightQuantizer",
+    "Int8DynActInt4WeightGPTQQuantizer",
+]
+
 
 __all__ = [
     "apply_weight_only_int8_quant",
@@ -45,7 +48,7 @@ __all__ = [
     "swap_conv2d_1x1_to_linear",
     "Quantizer",
     "TwoStepQuantizer",
-]
+] + (_AFTER_TORCH_2_4_ONLY if TORCH_VERSION_AFTER_2_4 else [])
 
 
 ############################# Unified Quantization APIs ##############################
@@ -221,583 +224,590 @@ def swap_conv2d_1x1_to_linear(model, filter_fn=None):
     )
 
 
-from .GPTQ import lm_eval_available
-
-if lm_eval_available:
-    from .GPTQ import (
-        evaluate,
-        GenericGPTQRunner,
-        get_task_dict,
-        InputRecorder,
-        lm_eval,
-        MultiInput,
+if TORCH_VERSION_AFTER_2_4:
+    from .quant_primitives import (
+        get_group_qparams_symmetric,
+        group_quantize_tensor_symmetric,
+        per_token_dynamic_quant,
     )
-else:
-    logging.info("lm_eval not available, skip defining GPTQQuantizer")
 
+    from .GPTQ import lm_eval_available
 
-class GPTQQuantizer(Quantizer):
-    """
-    This class implements a GPTQ Quantizer that can be used to apply GPTQ to a model in concert with the GenericGPTQRunner class.
-    Unlike the base Quantizer class, the user does not need to implement the create_quantized_state_dict, instead they have to reimplement
-    __init__ such that it defines the functions for the quantization mode. User is expected to reimplement convert_for_runtime.
-
-    The following functions (which must be defined in __init__) are used to define the quantization mode for both GPTQ and
-    create_quantized_state_dict. Here is a description of each function.
-
-    get_qparams_func:
-        A function that calculates the quantization qparams for an input tensor.
-        Args:
-            weight: A 2d weight tensor with non-integer dtype.
-        Returns:
-            qparams: it can have any format but will need to be handled by the other defined functions below.
-
-    quantize_func:
-        A function that applies quantization to an input tensor. It should be noted
-        that this function needs to be able to handle quantizing the entire weight tensor, a single group,
-        or a single column.
-        Args:
-            weight: A 2d weight tensor with non-integer dtype.
-            qparams: the output from get_qparams_func
-        Returns:
-            quantized_weight: A 2d quantized weight tensor (generally with an integer dtype)
-
-
-    dequantize_func:
-        A function that dequantizes an input quantized weight tensor. It should be noted
-        that this function needs to be able to handle dequantizing the entire weight tensor, a single group,
-        or a single column.
-        Args:
-            quantized_weight: A 2d quantized weight tensor (generally with an integer dtype)
-            qparams: the output from get_qparams_func
-        Returns:
-            weight: A 2d weight tensor with non-integer dtype.
-
-    combine_qparams_list_func:
-        A function that combines several qparams into one qparam.
-        Args:
-            qparams_list: a list of qparams objects, each obtained by calling get_qparams_func
-            on a single group from a weight tensor
-        Returns:
-            qparams: an object of the same format as the qparams above.
-
-    skip_layer_func:
-        A function that determines which linear layers should be skipped during GPTQ
-        Args:
-            weight: A 2d weight tensor with non-integer dtype.
-        Returns:
-            skip: boolean indicating whether layer should be skipped
-
-    make_names_and_values_dict_func:
-        A function that prepares the qparams and quantized_weight and creates a dictionary indicating how they
-        should be inserted into the state_dict. Generally any packing of the weight and qparams should be done here.
-        Args:
-            quantized_weight: A 2d quantized weight tensor (generally with an integer dtype)
-            qparams: the output from get_qparams_func
-        Returns:
-            names_and_values_dict: a dictionary mapping the name of the parameters of the quantized module to the
-            corresponding quantized weights and qparams.
-    """
-
-    def __init__(self):
-
-        assert self.get_qparams_func is not None
-
-        assert self.quantize_func is not None
-
-        assert self.dequantize_func is not None
-
-        assert self.combine_qparams_list_func is not None
-
-        #  `make_names_and_values_dict_func`.
-        assert self.make_names_and_values_dict_func is not None
-
-    @staticmethod
-    def get_inputs(
-        model,
-        tokenizer,
-        calibration_tasks,
-        calibration_limit,
-        calibration_seq_length,
-        pad_calibration_inputs,
-    ) -> "MultiInput":
-        input_recorder = InputRecorder(
-            model,
-            tokenizer,
-            calibration_seq_length,
-            pad_calibration_inputs,
+    if lm_eval_available:
+        from .GPTQ import (
+            evaluate,
+            GenericGPTQRunner,
+            get_task_dict,
+            InputRecorder,
+            lm_eval,
+            MultiInput,
         )
+    else:
+        logging.info("lm_eval not available, skip defining GPTQQuantizer")
 
-        try:
 
-            lm_eval.tasks.initialize_tasks()
-        except:
-            pass
+    class GPTQQuantizer(Quantizer):
+        """
+        This class implements a GPTQ Quantizer that can be used to apply GPTQ to a model in concert with the GenericGPTQRunner class.
+        Unlike the base Quantizer class, the user does not need to implement the create_quantized_state_dict, instead they have to reimplement
+        __init__ such that it defines the functions for the quantization mode. User is expected to reimplement convert_for_runtime.
 
-        task_dict = get_task_dict(calibration_tasks)
-        print("Obtaining GPTQ calibration inputs on: ", calibration_tasks)
+        The following functions (which must be defined in __init__) are used to define the quantization mode for both GPTQ and
+        create_quantized_state_dict. Here is a description of each function.
 
-        evaluate(
-            input_recorder,
-            task_dict,
-            limit=calibration_limit,
-        )
-        inputs = input_recorder.get_recorded_inputs()
-        assert inputs is not None, (
-            f"No inputs were collected, use a task other than {calibration_tasks}, "
-            + "use option pad_calibration_inputs, or decrease calibration_sequence_length (currently "
-            + f"{calibration_seq_length})"
-        )
-        print(f"Obtained {len(inputs[0].values)} calibration samples")
-        return inputs
+        get_qparams_func:
+            A function that calculates the quantization qparams for an input tensor.
+            Args:
+                weight: A 2d weight tensor with non-integer dtype.
+            Returns:
+                qparams: it can have any format but will need to be handled by the other defined functions below.
 
-    @torch.no_grad()
-    def _create_quantized_state_dict(
-        self,
-        model,
-        tokenizer,
-        blocksize,
-        percdamp,
-        groupsize,
-        calibration_tasks,
-        calibration_limit,
-        calibration_seq_length,
-        pad_calibration_inputs,
-        #  `typing.Dict[<key type>, <value type>]` to avoid runtime subscripting errors.
-    ) -> Dict:
-        inputs = GPTQQuantizer.get_inputs(
+        quantize_func:
+            A function that applies quantization to an input tensor. It should be noted
+            that this function needs to be able to handle quantizing the entire weight tensor, a single group,
+            or a single column.
+            Args:
+                weight: A 2d weight tensor with non-integer dtype.
+                qparams: the output from get_qparams_func
+            Returns:
+                quantized_weight: A 2d quantized weight tensor (generally with an integer dtype)
+
+
+        dequantize_func:
+            A function that dequantizes an input quantized weight tensor. It should be noted
+            that this function needs to be able to handle dequantizing the entire weight tensor, a single group,
+            or a single column.
+            Args:
+                quantized_weight: A 2d quantized weight tensor (generally with an integer dtype)
+                qparams: the output from get_qparams_func
+            Returns:
+                weight: A 2d weight tensor with non-integer dtype.
+
+        combine_qparams_list_func:
+            A function that combines several qparams into one qparam.
+            Args:
+                qparams_list: a list of qparams objects, each obtained by calling get_qparams_func
+                on a single group from a weight tensor
+            Returns:
+                qparams: an object of the same format as the qparams above.
+
+        skip_layer_func:
+            A function that determines which linear layers should be skipped during GPTQ
+            Args:
+                weight: A 2d weight tensor with non-integer dtype.
+            Returns:
+                skip: boolean indicating whether layer should be skipped
+
+        make_names_and_values_dict_func:
+            A function that prepares the qparams and quantized_weight and creates a dictionary indicating how they
+            should be inserted into the state_dict. Generally any packing of the weight and qparams should be done here.
+            Args:
+                quantized_weight: A 2d quantized weight tensor (generally with an integer dtype)
+                qparams: the output from get_qparams_func
+            Returns:
+                names_and_values_dict: a dictionary mapping the name of the parameters of the quantized module to the
+                corresponding quantized weights and qparams.
+        """
+
+        def __init__(self):
+
+            assert self.get_qparams_func is not None
+
+            assert self.quantize_func is not None
+
+            assert self.dequantize_func is not None
+
+            assert self.combine_qparams_list_func is not None
+
+            #  `make_names_and_values_dict_func`.
+            assert self.make_names_and_values_dict_func is not None
+
+        @staticmethod
+        def get_inputs(
             model,
             tokenizer,
             calibration_tasks,
             calibration_limit,
             calibration_seq_length,
             pad_calibration_inputs,
-        )
-        print("Tracing model for GPTQ")
-        GPTQ_runner = GenericGPTQRunner(
+        ) -> "MultiInput":
+            input_recorder = InputRecorder(
+                model,
+                tokenizer,
+                calibration_seq_length,
+                pad_calibration_inputs,
+            )
+
+            try:
+
+                lm_eval.tasks.initialize_tasks()
+            except:
+                pass
+
+            task_dict = get_task_dict(calibration_tasks)
+            print("Obtaining GPTQ calibration inputs on: ", calibration_tasks)
+
+            evaluate(
+                input_recorder,
+                task_dict,
+                limit=calibration_limit,
+            )
+            inputs = input_recorder.get_recorded_inputs()
+            assert inputs is not None, (
+                f"No inputs were collected, use a task other than {calibration_tasks}, "
+                + "use option pad_calibration_inputs, or decrease calibration_sequence_length (currently "
+                + f"{calibration_seq_length})"
+            )
+            print(f"Obtained {len(inputs[0].values)} calibration samples")
+            return inputs
+
+        @torch.no_grad()
+        def _create_quantized_state_dict(
+            self,
             model,
-            inputs,
+            tokenizer,
             blocksize,
             percdamp,
             groupsize,
-        ).configure_quantization_mode(
-            self.get_qparams_func,  # pyre-ignore[16]
-            self.quantize_func,  # pyre-ignore[16]
-            self.dequantize_func,  # pyre-ignore[16]
-            self.combine_qparams_list_func,  # pyre-ignore[16]
-            self.make_names_and_values_dict_func,  # pyre-ignore[16]
-            self.skip_layer_func,  # pyre-ignore[16]
-        )
-        print("Applying GPTQ to weights")
-        GPTQ_runner.run()
-        return GPTQ_runner.get_quantized_state_dict()
+            calibration_tasks,
+            calibration_limit,
+            calibration_seq_length,
+            pad_calibration_inputs,
+            #  `typing.Dict[<key type>, <value type>]` to avoid runtime subscripting errors.
+        ) -> Dict:
+            inputs = GPTQQuantizer.get_inputs(
+                model,
+                tokenizer,
+                calibration_tasks,
+                calibration_limit,
+                calibration_seq_length,
+                pad_calibration_inputs,
+            )
+            print("Tracing model for GPTQ")
+            GPTQ_runner = GenericGPTQRunner(
+                model,
+                inputs,
+                blocksize,
+                percdamp,
+                groupsize,
+            ).configure_quantization_mode(
+                self.get_qparams_func,  # pyre-ignore[16]
+                self.quantize_func,  # pyre-ignore[16]
+                self.dequantize_func,  # pyre-ignore[16]
+                self.combine_qparams_list_func,  # pyre-ignore[16]
+                self.make_names_and_values_dict_func,  # pyre-ignore[16]
+                self.skip_layer_func,  # pyre-ignore[16]
+            )
+            print("Applying GPTQ to weights")
+            GPTQ_runner.run()
+            return GPTQ_runner.get_quantized_state_dict()
 
-    def _convert_for_runtime(self, model: torch.nn.Module) -> "nn.Module":
-        raise NotImplementedError("_convert_for_runtime not implemented")
+        def _convert_for_runtime(self, model: torch.nn.Module) -> "nn.Module":
+            raise NotImplementedError("_convert_for_runtime not implemented")
 
-    @torch.no_grad()
-    def quantize(self, model: torch.nn.Module, **kwargs: Any) -> torch.nn.Module:
-        state_dict = self._create_quantized_state_dict(
-            model,
-            self.tokenizer,
-            self.blocksize,
-            self.percdamp,
-            self.groupsize,
-            self.calibration_tasks,
-            self.calibration_limit,
-            self.calibration_seq_length,
-            self.pad_calibration_inputs,
-        )
-        model = self._convert_for_runtime(model)
-        model.load_state_dict(state_dict, strict=False)
-        return model
+        @torch.no_grad()
+        def quantize(self, model: torch.nn.Module, **kwargs: Any) -> torch.nn.Module:
+            state_dict = self._create_quantized_state_dict(
+                model,
+                self.tokenizer,
+                self.blocksize,
+                self.percdamp,
+                self.groupsize,
+                self.calibration_tasks,
+                self.calibration_limit,
+                self.calibration_seq_length,
+                self.pad_calibration_inputs,
+            )
+            model = self._convert_for_runtime(model)
+            model.load_state_dict(state_dict, strict=False)
+            return model
 
 
-def linear_forward_8da4w(
-    x,
-    weight_int8,
-    scales,
-    zeros,
-    out_features,
-    group_size,
-    precision,
-):
-    x = per_token_dynamic_quant(x)
-    # TODO: verify and remove following reshape code
-    # origin_x_size = x.size()
-    # x = x.reshape(-1, origin_x_size[-1])
-
-    # TODO: better API
-    # weight_int8 = torch.ops.quantized_decomposed.unpack_int4_to_int8(weight_int4packed)
-    n_bit = 4
-    quant_min = -(2 ** (n_bit - 1))
-    quant_max = 2 ** (n_bit - 1) - 1
-    w_dq = torch.ops.quantized_decomposed.dequantize_per_channel_group(
+    def linear_forward_8da4w(
+        x,
         weight_int8,
         scales,
         zeros,
-        quant_min,
-        quant_max,
-        torch.int8,
+        out_features,
         group_size,
         precision,
-    )
-
-    # x = x.to(torch.float16)
-    # w_dq = w_dq.to(torch.float16)
-    c = torch.nn.functional.linear(x, w_dq)
-
-    # new_shape = origin_x_size[:-1] + (out_features,)
-    # c = c.reshape(new_shape)
-
-    return c
-
-
-class Int8DynActInt4WeightLinear(torch.nn.Module):
-    __constants__ = ["in_features", "out_features"]
-
-    in_features: int
-    out_features: int
-    weight: torch.Tensor
-
-    """
-    This module implements a dynamic quantized linear layer with int4 weight.
-    Weights are per channel groupwise quantized. Parameters of importance
-    group_size: the number of elements in each quantized group
-    precision: precision of input and output. e.g. torch.float32 means input
-    activation is float32 and output is float32.
-    scales_precision: precision of per group scale.
-    """
-
-    def __init__(
-        self,
-        in_features: int,
-        out_features: int,
-        bias=True,
-        device=None,
-        dtype=None,
-        group_size: int = 256,
-        precision: torch.dtype = torch.float32,
-        scales_precision: torch.dtype = torch.float32,
-    ) -> None:
-        super().__init__()
-        # always pad if needed since it becomes a noop at runtime if not needed
-        # self.origin_in_features = in_features
-        assert (
-            in_features % group_size == 0
-        ), f"require in_features:{in_features} % group_size:{group_size} == 0"
-        # in_features = _calc_padded_size_linear_int4(
-        #    in_features, group_size
-        # )
-        self.in_features = in_features
-        self.out_features = out_features
-        assert not bias, "require bias=False"
-        # TODO: align groupsize naming
-        self.group_size = group_size
-        # Precision of the activation which also indicates
-        # output precision of the dynamically quantized linear layer
-        # that his module represents.
-        self.precision = precision
-
-        # currently storing unpacked int8 weights
-        self.register_buffer(
-            "weight",
-            torch.empty((out_features, in_features), dtype=torch.int8),
-        )
-        self.register_buffer(
-            "scales",
-            torch.empty(
-                (out_features, in_features // group_size),
-                dtype=scales_precision,
-            ),
-        )
-        self.register_buffer(
-            "zeros",
-            torch.empty(
-                (out_features, in_features // group_size),
-                dtype=scales_precision,
-            ),
-        )
-
-    def forward(self, input: torch.Tensor) -> torch.Tensor:
-        input = input.to(self.precision)
-        # padding is removed for perf
-        # input = F.pad(input, pad=(0, self.in_features - self.origin_in_features))
-        return linear_forward_8da4w(
-            input,
-            self.weight,
-            self.scales,
-            self.zeros,
-            self.out_features,
-            self.group_size,
-            self.precision,
-        )
-
-
-from functools import reduce
-from math import gcd
-
-
-def find_multiple(n: int, *args: Tuple[int]) -> int:
-    # TODO: this change is reverted right now in gpt-fast
-    k: int = reduce(lambda x, y: x * y // gcd(x, y), args + (1,))  # type: ignore[9]
-    if n % k == 0:
-        return n
-    return n + k - (n % k)
-
-
-def _check_linear_int4_k(k, group_size=1):
-    return k % group_size == 0
-
-
-def _calc_padded_size_linear_int4(k, groupsize=1):
-    return find_multiple(k, groupsize)
-
-
-def pack_scales_and_zeros(scales, zeros, precision=torch.float32):
-    assert scales.shape == zeros.shape
-    assert scales.dtype == precision
-    assert zeros.dtype == precision
-    return (
-        torch.cat(
-            [
-                scales.reshape(scales.size(0), scales.size(1), 1),
-                zeros.reshape(zeros.size(0), zeros.size(1), 1),
-            ],
-            2,
-        )
-        .transpose(0, 1)
-        .contiguous()
-    )
-
-
-def unpack_scales_and_zeros(scales_and_zeros):
-    assert len(scales_and_zeros.shape) == 3 and scales_and_zeros.shape[2] == 2
-    assert scales_and_zeros.dtype == torch.float
-    return torch.split(scales_and_zeros.transpose(0, 1), 1, 2)
-
-
-def replace_linear_8da4w(
-    module,
-    group_size,
-    padding_allowed,
-    precision,
-    scales_precision,
-):
-    for name, child in module.named_children():
-        if isinstance(child, nn.Linear):
-            if _check_linear_int4_k(child.in_features, group_size) or padding_allowed:
-                setattr(
-                    module,
-                    name,
-                    Int8DynActInt4WeightLinear(
-                        child.in_features,
-                        child.out_features,
-                        bias=False,
-                        group_size=group_size,
-                        precision=precision,
-                        scales_precision=scales_precision,
-                    ),
-                )
-        else:
-            replace_linear_8da4w(
-                child,
-                group_size,
-                padding_allowed,
-                precision,
-                scales_precision,
-            )
-
-
-class Int8DynActInt4WeightQuantizer(Quantizer):
-    def __init__(
-        self,
-        group_size: int = 256,
-        padding_allowed: bool = False,
-        precision: torch.dtype = torch.float32,
-        scales_precision: torch.dtype = torch.float32,
-    ) -> None:
-        self.group_size: int = group_size
-        self.padding_allowed: bool = padding_allowed
-        self.precision: torch.dtype = precision
-        self.scales_precision: torch.dtype = scales_precision
-        # assert group_size in [32, 64, 128, 256]
-
-    @torch.no_grad()
-    def _create_quantized_state_dict(
-        self, model: torch.nn.Module
-    ) -> Dict[str, torch.Tensor]:
-        cur_state_dict = model.state_dict()
-        for fqn, mod in model.named_modules():
-            if isinstance(mod, torch.nn.Linear):
-                assert not mod.bias
-                out_features = mod.out_features
-                in_features = mod.in_features
-                # assert out_features % 8 == 0, "require out_features % 8 == 0"
-                print(f"linear: {fqn}, in={in_features}, out={out_features}")
-
-                assert (
-                    in_features % self.group_size == 0
-                ), f"require in_features:{in_features} % self.group_size:{self.group_size} == 0"
-
-                weight = mod.weight.data
-                """
-                if not _check_linear_int4_k(
-                    in_features, self.group_size
-                ):
-                    if self.padding_allowed:
-                        print(
-                            f"warning: {fqn} is padded to satisfy in_features % 1024 == 0"
-                        )
-                        padded_in_features = _calc_padded_size_linear_int4(
-                            in_features, self.group_size
-                        )
-                        weight = F.pad(
-                            weight, pad=(0, padded_in_features - in_features)
-                        )
-                    else:
-                        raise RuntimeError(
-                            f"warning: {fqn} is skipped, int4 requires that in_features is 32, 64, or is divisible by 1024, "
-                            + "and that group_size"
-                        )
-                """
-                (
-                    weight_int8,
-                    scales,
-                    zeros,
-                ) = group_quantize_tensor_symmetric(
-                    weight.to(self.precision),
-                    4,  # n_bit
-                    self.group_size,
-                    self.scales_precision,
-                )
-                cur_state_dict[f"{fqn}.weight"] = weight_int8.to("cpu")
-                cur_state_dict[f"{fqn}.scales"] = scales.to("cpu")
-                cur_state_dict[f"{fqn}.zeros"] = zeros.to("cpu")
-                # TODO: support bias?
-
-        return cur_state_dict
-
-    def _convert_for_runtime(self, model: torch.nn.Module) -> torch.nn.Module:
-        replace_linear_8da4w(
-            model,
-            self.group_size,
-            self.padding_allowed,
-            self.precision,
-            self.scales_precision,
-        )
-        return model
-
-    def quantize(
-        self, model: torch.nn.Module, *args: Any, **kwargs: Any
-    ) -> torch.nn.Module:
-        state_dict = self._create_quantized_state_dict(model)
-        model = self._convert_for_runtime(model)
-        # TODO: make it strict
-        model.load_state_dict(state_dict, strict=False)
-        return model
-
-
-class Int8DynActInt4WeightGPTQQuantizer(GPTQQuantizer):
-
-    def __init__(
-        self,
-        tokenizer,
-        blocksize,
-        percdamp,
-        groupsize,
-        calibration_tasks,
-        calibration_limit,
-        calibration_seq_length,
-        pad_calibration_inputs,
-        inner_k_tiles=8,
-        padding_allowed=True,
-        precision=torch.float32,
     ):
+        x = per_token_dynamic_quant(x)
+        # TODO: verify and remove following reshape code
+        # origin_x_size = x.size()
+        # x = x.reshape(-1, origin_x_size[-1])
 
-        self.tokenizer = tokenizer
-
-        self.blocksize = blocksize
-
-        self.percdamp = percdamp
-
-        self.groupsize = groupsize
-
-        self.calibration_tasks = calibration_tasks
-
-        self.calibration_limit = calibration_limit
-
-        self.calibration_seq_length = calibration_seq_length
-
-        self.pad_calibration_inputs = pad_calibration_inputs
-
-        self.inner_k_tiles = inner_k_tiles
-
-        self.padding_allowed = padding_allowed
-
-        self.precision = precision
-
-        self.dyn_quant_func = lambda x: per_token_dynamic_quant(x)
+        # TODO: better API
+        # weight_int8 = torch.ops.quantized_decomposed.unpack_int4_to_int8(weight_int4packed)
         n_bit = 4
-
-        self.get_qparams_func = lambda w: get_group_qparams_symmetric(
-            w, n_bit, groupsize, self.precision
-        )
         quant_min = -(2 ** (n_bit - 1))
         quant_max = 2 ** (n_bit - 1) - 1
-
-        self.quantize_func = lambda w, qparams: torch.ops.quantized_decomposed.quantize_per_channel_group(
-            w, qparams[0], qparams[1], quant_min, quant_max, torch.int8, groupsize
-        )
-
-        self.dequantize_func = lambda q, qparams: torch.ops.quantized_decomposed.dequantize_per_channel_group(
-            q,
-            qparams[0],
-            qparams[1],
+        w_dq = torch.ops.quantized_decomposed.dequantize_per_channel_group(
+            weight_int8,
+            scales,
+            zeros,
             quant_min,
             quant_max,
             torch.int8,
-            groupsize,
-            self.precision,
+            group_size,
+            precision,
         )
 
-        self.combine_qparams_list_func = lambda qparams_list: [
-            torch.cat(x, dim=1) for x in zip(*qparams_list)
-        ]
-        # skip unless padding_allowed=True or its correctly sized
+        # x = x.to(torch.float16)
+        # w_dq = w_dq.to(torch.float16)
+        c = torch.nn.functional.linear(x, w_dq)
 
-        self.skip_layer_func = lambda linear_weight: not (
-            _check_linear_int4_k(linear_weight.shape[-1], groupsize) or padding_allowed
-        )
+        # new_shape = origin_x_size[:-1] + (out_features,)
+        # c = c.reshape(new_shape)
 
-        # we need to do the padding here, both for q and the qparams if necessary
+        return c
 
-        def make_names_and_values_dict_func(q, qparams):
-            k = q.shape[1]
-            new_k = _calc_padded_size_linear_int4(k, groupsize)
-            # how much we need to pad the weight
-            delta_k = new_k - q.shape[1]
-            final_q = F.pad(q, pad=(0, delta_k))
-            scales = qparams[0].to(self.precision)
-            zeros = qparams[1].to(self.precision)
-            # scales_and_zeros = pack_scales_and_zeros(*qparams, precision=self.precision)
-            # how many new groups we need for padded weight
-            # delta_groups = new_k // groupsize - scales_and_zeros.shape[0]
-            # TODO: split scales and zero_points
-            # final_s_and_z = F.pad(
-            #     scales_and_zeros, pad=(0, 0, 0, 0, 0, delta_groups), value=1
+
+    class Int8DynActInt4WeightLinear(torch.nn.Module):
+        __constants__ = ["in_features", "out_features"]
+
+        in_features: int
+        out_features: int
+        weight: torch.Tensor
+
+        """
+        This module implements a dynamic quantized linear layer with int4 weight.
+        Weights are per channel groupwise quantized. Parameters of importance
+        group_size: the number of elements in each quantized group
+        precision: precision of input and output. e.g. torch.float32 means input
+        activation is float32 and output is float32.
+        scales_precision: precision of per group scale.
+        """
+
+        def __init__(
+            self,
+            in_features: int,
+            out_features: int,
+            bias=True,
+            device=None,
+            dtype=None,
+            group_size: int = 256,
+            precision: torch.dtype = torch.float32,
+            scales_precision: torch.dtype = torch.float32,
+        ) -> None:
+            super().__init__()
+            # always pad if needed since it becomes a noop at runtime if not needed
+            # self.origin_in_features = in_features
+            assert (
+                in_features % group_size == 0
+            ), f"require in_features:{in_features} % group_size:{group_size} == 0"
+            # in_features = _calc_padded_size_linear_int4(
+            #    in_features, group_size
             # )
-            return {"weight": final_q, "scales": scales, "zeros": zeros}
+            self.in_features = in_features
+            self.out_features = out_features
+            assert not bias, "require bias=False"
+            # TODO: align groupsize naming
+            self.group_size = group_size
+            # Precision of the activation which also indicates
+            # output precision of the dynamically quantized linear layer
+            # that his module represents.
+            self.precision = precision
 
-        self.make_names_and_values_dict_func = make_names_and_values_dict_func
-        super().__init__()
+            # currently storing unpacked int8 weights
+            self.register_buffer(
+                "weight",
+                torch.empty((out_features, in_features), dtype=torch.int8),
+            )
+            self.register_buffer(
+                "scales",
+                torch.empty(
+                    (out_features, in_features // group_size),
+                    dtype=scales_precision,
+                ),
+            )
+            self.register_buffer(
+                "zeros",
+                torch.empty(
+                    (out_features, in_features // group_size),
+                    dtype=scales_precision,
+                ),
+            )
 
-    def _convert_for_runtime(self, model):
-        replace_linear_8da4w(
-            model,
-            self.groupsize,
-            self.padding_allowed,
-            self.precision,
-            self.precision,
+        def forward(self, input: torch.Tensor) -> torch.Tensor:
+            input = input.to(self.precision)
+            # padding is removed for perf
+            # input = F.pad(input, pad=(0, self.in_features - self.origin_in_features))
+            return linear_forward_8da4w(
+                input,
+                self.weight,
+                self.scales,
+                self.zeros,
+                self.out_features,
+                self.group_size,
+                self.precision,
+            )
+
+
+    from functools import reduce
+    from math import gcd
+
+
+    def find_multiple(n: int, *args: Tuple[int]) -> int:
+        # TODO: this change is reverted right now in gpt-fast
+        k: int = reduce(lambda x, y: x * y // gcd(x, y), args + (1,))  # type: ignore[9]
+        if n % k == 0:
+            return n
+        return n + k - (n % k)
+
+
+    def _check_linear_int4_k(k, group_size=1):
+        return k % group_size == 0
+
+
+    def _calc_padded_size_linear_int4(k, groupsize=1):
+        return find_multiple(k, groupsize)
+
+
+    def pack_scales_and_zeros(scales, zeros, precision=torch.float32):
+        assert scales.shape == zeros.shape
+        assert scales.dtype == precision
+        assert zeros.dtype == precision
+        return (
+            torch.cat(
+                [
+                    scales.reshape(scales.size(0), scales.size(1), 1),
+                    zeros.reshape(zeros.size(0), zeros.size(1), 1),
+                ],
+                2,
+            )
+            .transpose(0, 1)
+            .contiguous()
         )
-        return model
+
+
+    def unpack_scales_and_zeros(scales_and_zeros):
+        assert len(scales_and_zeros.shape) == 3 and scales_and_zeros.shape[2] == 2
+        assert scales_and_zeros.dtype == torch.float
+        return torch.split(scales_and_zeros.transpose(0, 1), 1, 2)
+
+
+    def replace_linear_8da4w(
+        module,
+        group_size,
+        padding_allowed,
+        precision,
+        scales_precision,
+    ):
+        for name, child in module.named_children():
+            if isinstance(child, nn.Linear):
+                if _check_linear_int4_k(child.in_features, group_size) or padding_allowed:
+                    setattr(
+                        module,
+                        name,
+                        Int8DynActInt4WeightLinear(
+                            child.in_features,
+                            child.out_features,
+                            bias=False,
+                            group_size=group_size,
+                            precision=precision,
+                            scales_precision=scales_precision,
+                        ),
+                    )
+            else:
+                replace_linear_8da4w(
+                    child,
+                    group_size,
+                    padding_allowed,
+                    precision,
+                    scales_precision,
+                )
+
+
+    class Int8DynActInt4WeightQuantizer(Quantizer):
+        def __init__(
+            self,
+            group_size: int = 256,
+            padding_allowed: bool = False,
+            precision: torch.dtype = torch.float32,
+            scales_precision: torch.dtype = torch.float32,
+        ) -> None:
+            self.group_size: int = group_size
+            self.padding_allowed: bool = padding_allowed
+            self.precision: torch.dtype = precision
+            self.scales_precision: torch.dtype = scales_precision
+            # assert group_size in [32, 64, 128, 256]
+
+        @torch.no_grad()
+        def _create_quantized_state_dict(
+            self, model: torch.nn.Module
+        ) -> Dict[str, torch.Tensor]:
+            cur_state_dict = model.state_dict()
+            for fqn, mod in model.named_modules():
+                if isinstance(mod, torch.nn.Linear):
+                    assert not mod.bias
+                    out_features = mod.out_features
+                    in_features = mod.in_features
+                    # assert out_features % 8 == 0, "require out_features % 8 == 0"
+                    print(f"linear: {fqn}, in={in_features}, out={out_features}")
+
+                    assert (
+                        in_features % self.group_size == 0
+                    ), f"require in_features:{in_features} % self.group_size:{self.group_size} == 0"
+
+                    weight = mod.weight.data
+                    """
+                    if not _check_linear_int4_k(
+                        in_features, self.group_size
+                    ):
+                        if self.padding_allowed:
+                            print(
+                                f"warning: {fqn} is padded to satisfy in_features % 1024 == 0"
+                            )
+                            padded_in_features = _calc_padded_size_linear_int4(
+                                in_features, self.group_size
+                            )
+                            weight = F.pad(
+                                weight, pad=(0, padded_in_features - in_features)
+                            )
+                        else:
+                            raise RuntimeError(
+                                f"warning: {fqn} is skipped, int4 requires that in_features is 32, 64, or is divisible by 1024, "
+                                + "and that group_size"
+                            )
+                    """
+                    (
+                        weight_int8,
+                        scales,
+                        zeros,
+                    ) = group_quantize_tensor_symmetric(
+                        weight.to(self.precision),
+                        4,  # n_bit
+                        self.group_size,
+                        self.scales_precision,
+                    )
+                    cur_state_dict[f"{fqn}.weight"] = weight_int8.to("cpu")
+                    cur_state_dict[f"{fqn}.scales"] = scales.to("cpu")
+                    cur_state_dict[f"{fqn}.zeros"] = zeros.to("cpu")
+                    # TODO: support bias?
+
+            return cur_state_dict
+
+        def _convert_for_runtime(self, model: torch.nn.Module) -> torch.nn.Module:
+            replace_linear_8da4w(
+                model,
+                self.group_size,
+                self.padding_allowed,
+                self.precision,
+                self.scales_precision,
+            )
+            return model
+
+        def quantize(
+            self, model: torch.nn.Module, *args: Any, **kwargs: Any
+        ) -> torch.nn.Module:
+            state_dict = self._create_quantized_state_dict(model)
+            model = self._convert_for_runtime(model)
+            # TODO: make it strict
+            model.load_state_dict(state_dict, strict=False)
+            return model
+
+
+    class Int8DynActInt4WeightGPTQQuantizer(GPTQQuantizer):
+
+        def __init__(
+            self,
+            tokenizer,
+            blocksize,
+            percdamp,
+            groupsize,
+            calibration_tasks,
+            calibration_limit,
+            calibration_seq_length,
+            pad_calibration_inputs,
+            inner_k_tiles=8,
+            padding_allowed=True,
+            precision=torch.float32,
+        ):
+
+            self.tokenizer = tokenizer
+
+            self.blocksize = blocksize
+
+            self.percdamp = percdamp
+
+            self.groupsize = groupsize
+
+            self.calibration_tasks = calibration_tasks
+
+            self.calibration_limit = calibration_limit
+
+            self.calibration_seq_length = calibration_seq_length
+
+            self.pad_calibration_inputs = pad_calibration_inputs
+
+            self.inner_k_tiles = inner_k_tiles
+
+            self.padding_allowed = padding_allowed
+
+            self.precision = precision
+
+            self.dyn_quant_func = lambda x: per_token_dynamic_quant(x)
+            n_bit = 4
+
+            self.get_qparams_func = lambda w: get_group_qparams_symmetric(
+                w, n_bit, groupsize, self.precision
+            )
+            quant_min = -(2 ** (n_bit - 1))
+            quant_max = 2 ** (n_bit - 1) - 1
+
+            self.quantize_func = lambda w, qparams: torch.ops.quantized_decomposed.quantize_per_channel_group(
+                w, qparams[0], qparams[1], quant_min, quant_max, torch.int8, groupsize
+            )
+
+            self.dequantize_func = lambda q, qparams: torch.ops.quantized_decomposed.dequantize_per_channel_group(
+                q,
+                qparams[0],
+                qparams[1],
+                quant_min,
+                quant_max,
+                torch.int8,
+                groupsize,
+                self.precision,
+            )
+
+            self.combine_qparams_list_func = lambda qparams_list: [
+                torch.cat(x, dim=1) for x in zip(*qparams_list)
+            ]
+            # skip unless padding_allowed=True or its correctly sized
+
+            self.skip_layer_func = lambda linear_weight: not (
+                _check_linear_int4_k(linear_weight.shape[-1], groupsize) or padding_allowed
+            )
+
+            # we need to do the padding here, both for q and the qparams if necessary
+
+            def make_names_and_values_dict_func(q, qparams):
+                k = q.shape[1]
+                new_k = _calc_padded_size_linear_int4(k, groupsize)
+                # how much we need to pad the weight
+                delta_k = new_k - q.shape[1]
+                final_q = F.pad(q, pad=(0, delta_k))
+                scales = qparams[0].to(self.precision)
+                zeros = qparams[1].to(self.precision)
+                # scales_and_zeros = pack_scales_and_zeros(*qparams, precision=self.precision)
+                # how many new groups we need for padded weight
+                # delta_groups = new_k // groupsize - scales_and_zeros.shape[0]
+                # TODO: split scales and zero_points
+                # final_s_and_z = F.pad(
+                #     scales_and_zeros, pad=(0, 0, 0, 0, 0, delta_groups), value=1
+                # )
+                return {"weight": final_q, "scales": scales, "zeros": zeros}
+
+            self.make_names_and_values_dict_func = make_names_and_values_dict_func
+            super().__init__()
+
+        def _convert_for_runtime(self, model):
+            replace_linear_8da4w(
+                model,
+                self.groupsize,
+                self.padding_allowed,
+                self.precision,
+                self.precision,
+            )
+            return model

--- a/torchao/quantization/quant_primitives.py
+++ b/torchao/quantization/quant_primitives.py
@@ -4,19 +4,20 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-import math
-from typing import Optional, Tuple
-
 import torch
 from torch._dynamo import is_compiling as dynamo_is_compiling
 from torch._higher_order_ops.out_dtype import out_dtype
-from torch.ao.quantization.fx._decomposed import (
-    _quant_min_max_bounds_check,
-    quantized_decomposed_lib,
-)
+from torch.ao.quantization.fx._decomposed import quantized_decomposed_lib
 from torch.library import impl
 
 from torchao.kernel.intmm_triton import int_scaled_matmul
+from .utils import TORCH_VERSION_AFTER_2_4
+
+
+_AFTER_TORCH_2_4_ONLY = [
+    "per_token_dynamic_quant",
+    "get_group_qparams_symmetric",
+]
 
 __all__ = [
     "safe_int_mm",
@@ -37,9 +38,7 @@ __all__ = [
     "groupwise_affine_quantize_tensor",
     "groupwise_affine_dequantize_tensor",
     # TODO: need to clean up above functions
-    "per_token_dynamic_quant",
-    "get_group_qparams_symmetric",
-]
+] + (_AFTER_TORCH_2_4_ONLY if TORCH_VERSION_AFTER_2_4 else [])
 
 
 def safe_int_mm(input: torch.Tensor, mat2: torch.Tensor) -> torch.Tensor:
@@ -526,252 +525,6 @@ def groupwise_affine_dequantize_tensor(
     )
 
 
-# TODO: need some cleanups
-# TODO: move this to https://github.com/pytorch/pytorch/blob/main/torch/ao/quantization/fx/_decomposed.py
-quantized_decomposed_lib.define(
-    "choose_qparams_per_token(Tensor input, ScalarType dtype) -> (Tensor, Tensor)"
-)
-
-
-@impl(
-    quantized_decomposed_lib,
-    "choose_qparams_per_token",
-    "CompositeExplicitAutograd",
-)
-def choose_qparams_per_token(
-    input: torch.Tensor,
-    dtype: torch.dtype,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Choose quantization parameters for per token quantization. This means for a N dimension Tensor
-    (M1, M2, ...Mn, N), we calculate scales/zero_points for each N elements and quantize
-    every N elements with the same quantization parameter. The dimension for scales/zero_points
-    will be (M1 * M2 ... * Mn)
-
-    Args:
-       input (torch.Tensor): original float32/float16 Tensor
-       dtype (torch.dtype): dtype (e.g. torch.uint8) for input Tensor
-
-    Returns:
-        scales and zero_points, both float32 Tensors
-    """
-
-    scales = input.abs().amax(dim=-1, keepdim=True)
-    if scales.dtype == torch.float16:
-        scales = (
-            scales.float()
-        )  # want float scales to avoid overflows for fp16, (bf16 has wide enough range)
-    if dtype == torch.int8:
-        n_bits = 8
-        quant_max = 2 ** (n_bits - 1) - 1
-    else:
-        raise Exception(f"unsupported dtype in choose_qparams_per_token: {dtype}")
-
-    scales = scales.clamp(min=1e-5).div(quant_max)
-    zero_points = torch.zeros_like(scales)
-    return scales, zero_points
-
-
-@impl(
-    quantized_decomposed_lib,
-    "choose_qparams_per_token",
-    "Meta",
-)
-def choose_qparams_per_token_meta(
-    input: torch.Tensor,
-    dtype: torch.dtype,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    size = (1, input.size(-1))
-    return torch.empty(size, dtype=torch.double, device=input.device), torch.empty(
-        size, dtype=torch.int64, device=input.device
-    )
-
-
-# TODO: move this to https://github.com/pytorch/pytorch/blob/main/torch/ao/quantization/fx/_decomposed.py
-quantized_decomposed_lib.define(
-    "choose_qparams_per_token_asymmetric(Tensor input, ScalarType dtype) -> (Tensor, Tensor)"
-)
-
-
-@impl(
-    quantized_decomposed_lib,
-    "choose_qparams_per_token_asymmetric",
-    "CompositeExplicitAutograd",
-)
-def choose_qparams_per_token_asymmetric(
-    input: torch.Tensor,
-    dtype: torch.dtype,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Choose quantization parameters for per token quantization. This means for a N dimension Tensor
-    (M1, M2, ...Mn, N), we calculate scales/zero_points for each N elements and quantize
-    every N elements with the same quantization parameter. The dimension for scales/zero_points
-    will be (M1 * M2 ... * Mn)
-
-    Args:
-       input (torch.Tensor): original float32/float16 Tensor
-       dtype (torch.dtype): dtype (e.g. torch.uint8) for input Tensor
-
-    Returns:
-        scales and zero_points, both float32 Tensors
-    """
-    # Based on https://github.com/google/XNNPACK/blob/df156f0cf3db5a4576cc711123eeb54915f82ffc/src/xnnpack/quantization.h#L18
-    qmin, qmax = -128, 127
-    min_val, max_val = torch.aminmax(input, dim=-1, keepdim=True)
-    min_val_neg = torch.min(min_val, torch.zeros_like(min_val))
-    max_val_pos = torch.max(max_val, torch.zeros_like(max_val))
-    eps = torch.finfo(torch.float32).eps  # use xnnpack eps?
-
-    # scale
-    scale = (max_val_pos - min_val_neg) / float(qmax - qmin)
-    scale = scale.clamp(min=eps)
-
-    # zero point
-    descaled_min = min_val_neg / scale
-    descaled_max = max_val_pos / scale
-    zero_point_from_min_error = qmin + descaled_min
-    zero_point_from_max_error = qmax + descaled_max
-    zero_point = torch.where(
-        zero_point_from_min_error + zero_point_from_max_error > 0,
-        qmin - descaled_min,
-        qmax - descaled_max,
-    )
-    zero_point = torch.clamp(zero_point, qmin, qmax).round()
-
-    return scale.to(torch.float32), zero_point.to(torch.float32)
-
-
-@impl(
-    quantized_decomposed_lib,
-    "choose_qparams_per_token_asymmetric",
-    "Meta",
-)
-def choose_qparams_per_token_asymmetric_meta(
-    input: torch.Tensor,
-    dtype: torch.dtype,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    size = (1, input.size(-1))
-    return torch.empty(size, dtype=torch.double, device=input.device), torch.empty(
-        size, dtype=torch.int64, device=input.device
-    )
-
-
-def _per_token_quant_qparam_dim_check(input, scales, zero_points):
-    num_tokens = math.prod(list(input.size())[:-1])
-    assert (
-        num_tokens == scales.numel()
-    ), f"num_tokens: {num_tokens} scales: {scales.size()}"
-    assert (
-        num_tokens == zero_points.numel()
-    ), f"num_tokens: {num_tokens} zero_points: {zero_points.size()}"
-
-
-quantized_decomposed_lib.define(
-    "quantize_per_token(Tensor input, Tensor scales, Tensor zero_points, "
-    "int quant_min, int quant_max, ScalarType dtype) -> Tensor"
-)
-
-
-@impl(quantized_decomposed_lib, "quantize_per_token", "CompositeExplicitAutograd")
-def quantize_per_token(
-    input: torch.Tensor,
-    scales: torch.Tensor,
-    zero_points: torch.Tensor,
-    quant_min: int,
-    quant_max: int,
-    dtype: torch.dtype,
-):
-    """Per token quantization for the Tensor using the quantization parameters to map
-    from floating point to quantized values. This means for a N dimension Tensor
-    (M1, M2, ...Mn, N), we calculate scales/zero_points for each N elements and quantize
-    every N elements with the same quantization parameter. The dimension for scales/zero_points
-    will be (M1 * M2 ... * Mn)
-
-    Args:
-       input (torch.Tensor): original float32 or bfloat16 Tensor
-       scales (float32 torch.Tensor): quantization parameter for per token affine quantization
-       zero_points (int32 torch.Tensor): quantization parameter for per token affine quantization
-       quant_min (int): minimum quantized value for output Tensor
-       quant_max (int): maximum quantized value for output Tensor
-       dtype (torch.dtype): requested dtype (e.g. torch.uint8) for output Tensor
-
-    Returns:
-       Tensor with requested dtype (e.g. torch.uint8), note the quantization parameters
-       are not stored in the Tensor, we are storing them in function arguments instead
-    """
-    _quant_min_max_bounds_check(quant_min, quant_max, dtype)
-    _per_token_quant_qparam_dim_check(input, scales, zero_points)
-    input = (
-        torch.round(input / scales + zero_points).clamp(quant_min, quant_max).to(dtype)
-    )
-    return input
-
-
-@impl(quantized_decomposed_lib, "quantize_per_token", "Meta")
-def quantize_per_token_meta(
-    input: torch.Tensor,
-    scales: torch.Tensor,
-    zero_points: torch.Tensor,
-    quant_min: int,
-    quant_max: int,
-    dtype: torch.dtype,
-):
-    _quant_min_max_bounds_check(quant_min, quant_max, dtype)
-    return torch.empty_like(input, dtype=dtype)
-
-
-quantized_decomposed_lib.define(
-    "dequantize_per_token(Tensor input, Tensor scales, Tensor zero_points, "
-    "int quant_min, int quant_max, ScalarType dtype, ScalarType output_dtype) -> Tensor"
-)
-
-
-@impl(quantized_decomposed_lib, "dequantize_per_token", "CompositeExplicitAutograd")
-def dequantize_per_token(
-    input: torch.Tensor,
-    scales: torch.Tensor,
-    zero_points: torch.Tensor,
-    quant_min: int,
-    quant_max: int,
-    dtype: torch.dtype,
-    output_dtype: torch.dtype = torch.float32,
-):
-    """Per token dequantization for the Tensor using the quantization parameters to map
-    from floating point to quantized values. This means for a N dimension Tensor
-    (M1, M2, ...Mn, N), we calculate scales/zero_points for each N elements and quantize
-    every N elements with the same quantization parameter. The dimension for scales/zero_points
-    will be (M1 * M2 ... * Mn)
-
-    Args:
-       input (torch.Tensor): quantized Tensor (uint8, int8 etc.)
-       scales (float32 torch.Tensor): quantization parameter for per token affine quantization
-       zero_points (int32 torch.Tensor): quantization parameter for per token affine quantization
-       quant_min (int): minimum quantized value for input Tensor
-       quant_max (int): maximum quantized value for input Tensor
-       dtype (torch.dtype): dtype (e.g. torch.uint8) for input Tensor
-       output_dtype (torch.dtype): dtype (e.g. torch.float32) for output Tensor
-
-    Returns:
-       dequantized Tensor with dtype `output_dtype`
-    """
-    input = input - zero_points
-    input = input.to(output_dtype) * scales
-    return input
-
-
-@impl(quantized_decomposed_lib, "dequantize_per_token", "Meta")
-def dequantize_per_token_meta(
-    input: torch.Tensor,
-    scales: torch.Tensor,
-    zero_points: torch.Tensor,
-    quant_min: int,
-    quant_max: int,
-    dtype: torch.dtype,
-    output_dtype: torch.dtype = torch.float32,
-):
-    _quant_min_max_bounds_check(quant_min, quant_max, dtype)
-    # TODO: support fp16
-    return torch.empty_like(input, dtype=output_dtype)
-
-
 def get_group_qparams_symmetric(w, n_bit=4, groupsize=128, precision=torch.float32):
     # needed for GPTQ with padding
     if groupsize > w.shape[-1]:
@@ -818,215 +571,78 @@ def pack_scales_and_zeros(scales, zeros, precision=torch.float16):
     )
 
 
-quantized_decomposed_lib.define(
-    "quantize_per_channel_group(Tensor input, Tensor scales, Tensor zero_points, int quant_min, "
-    "int quant_max, ScalarType dtype, int group_size) -> Tensor"
-)
+if TORCH_VERSION_AFTER_2_4:
+    def group_quantize_tensor_symmetric(
+        w,
+        n_bit=4,
+        group_size=128,
+        precision=torch.float32,
+    ):
+        scales, zeros = get_group_qparams_symmetric(w, n_bit, group_size, precision)
+        n_bit = 4
+        max_int = 2 ** (n_bit - 1) - 1
+        min_int = -(2 ** (n_bit - 1))
+        # TODO: currently we don't know how to express torch.int4, we'll
+        # add torch.int4 to core later
+        w_int8 = torch.ops.quantized_decomposed.quantize_per_channel_group(
+            w, scales, zeros, min_int, max_int, torch.int8, group_size
+        )
+
+        return w_int8, scales, zeros
 
 
-# TODO: dtype is ignored for now
-@impl(
-    quantized_decomposed_lib, "quantize_per_channel_group", "CompositeExplicitAutograd"
-)
-def quantize_per_channel_group(
-    input: torch.Tensor,
-    scales: torch.Tensor,
-    zero_points: torch.Tensor,
-    quant_min: int,
-    quant_max: int,
-    dtype: torch.dtype,
-    group_size=128,
-):
-    assert group_size > 1
-    # needed for GPTQ single column quantize
-    if group_size > input.shape[-1] and scales.shape[-1] == 1:
-        group_size = input.shape[-1]
-
-    assert input.shape[-1] % group_size == 0
-    assert input.dim() == 2
-
-    # TODO: check for dtype, currently we can't express torch.int4 so it's omitted
-    to_quant = input.reshape(-1, group_size)
-    assert torch.isnan(to_quant).sum() == 0
-
-    scales = scales.reshape(-1, 1)
-    zero_points = zero_points.reshape(-1, 1)
-
-    input_int8 = (
-        to_quant.div(scales)
-        .add(zero_points)
-        .round()
-        .clamp_(quant_min, quant_max)
-        .to(dtype)
-        .reshape_as(input)
-    )
-
-    return input_int8
+    def down_size(size):
+        assert size[-1] % 2 == 0, f"{size} last dim not divisible by two"
+        return (*size[:-1], size[-1] // 2)
 
 
-@impl(quantized_decomposed_lib, "quantize_per_channel_group", "Meta")
-def quantize_per_channel_group_meta(
-    input: torch.Tensor,
-    scales: torch.Tensor,
-    zero_points: torch.Tensor,
-    quant_min: int,
-    quant_max: int,
-    dtype: torch.dtype,
-    group_size=128,
-):
-    """Groupwise quantization within each channel for an 2-d Tensor using the quantization parameters
-    to map from floating point to quantized values. This means for each row of a 2-d Tensor
-    (M, N), we calculate scales/zero_points for each `group_size` elements
-    and quantize every `group_size` elements with the same quantization parameter.
-    The dimension for scales/zero_points will be (M * ceil(N, group_size),)
-
-    Args:
-       input (torch.Tensor): original float32 or bfloat16 Tensor
-       scales (float32 torch.Tensor): quantization parameter for per channel group affine quantization
-       zero_points (int32 torch.Tensor): quantization parameter for per channel group affine quantization
-       quant_min (int): minimum quantized value for output Tensor
-       quant_max (int): maximum quantized value for output Tensor
-       dtype (torch.dtype): requested dtype (e.g. torch.uint8) for output Tensor
-
-    Returns:
-       Tensor with requested dtype (e.g. torch.uint8), note the quantization parameters
-       are not stored in the Tensor, we are storing them in function arguments instead
-    """
-    assert group_size > 1
-    # needed for GPTQ single column quantize
-    if group_size > input.shape[-1] and scales.shape[-1] == 1:
-        group_size = input.shape[-1]
-
-    assert input.shape[-1] % group_size == 0
-    assert input.dim() == 2
-    return torch.empty_like(input, dtype=dtype)
+    def up_size(size):
+        return (*size[:-1], size[-1] * 2)
 
 
-def group_quantize_tensor_symmetric(
-    w,
-    n_bit=4,
-    group_size=128,
-    precision=torch.float32,
-):
-    scales, zeros = get_group_qparams_symmetric(w, n_bit, group_size, precision)
-    n_bit = 4
-    max_int = 2 ** (n_bit - 1) - 1
-    min_int = -(2 ** (n_bit - 1))
-    # TODO: currently we don't know how to express torch.int4, we'll
-    # add torch.int4 to core later
-    w_int8 = torch.ops.quantized_decomposed.quantize_per_channel_group(
-        w, scales, zeros, min_int, max_int, torch.int8, group_size
-    )
-
-    return w_int8, scales, zeros
+    quantized_decomposed_lib.define("pack_int4_from_int8(Tensor int8_data) -> Tensor")
 
 
-quantized_decomposed_lib.define(
-    "dequantize_per_channel_group(Tensor input, Tensor scales, Tensor? zero_points, int quant_min, "
-    "int quant_max, ScalarType dtype, int group_size, ScalarType output_dtype) -> Tensor"
-)
+    @impl(quantized_decomposed_lib, "pack_int4_from_int8", "CompositeExplicitAutograd")
+    def pack_int4_from_int8(int8_data: torch.Tensor) -> torch.Tensor:
+        # converting to uint8 for operations
+        shape = int8_data.shape
+        assert shape[-1] % 2 == 0
+        int8_data = int8_data.contiguous().view(-1)
+        return (int8_data[::2] << 4 | int8_data[1::2]).view(down_size(shape))
 
 
-@impl(
-    quantized_decomposed_lib,
-    "dequantize_per_channel_group",
-    "CompositeExplicitAutograd",
-)
-def dequantize_per_channel_group(
-    w_int8: torch.Tensor,
-    scales: torch.Tensor,
-    zero_points: Optional[torch.Tensor],
-    quant_min: int,
-    quant_max: int,
-    dtype: torch.dtype,
-    group_size: int = 128,
-    output_dtype: torch.dtype = torch.float32,
-):
-    """Groupwise dequantization within each channel for an 2-d Tensor using the quantization parameters
-    to map from floating point to quantized values. This means for each row of a 2-d Tensor
-    (M, N), we calculate scales/zero_points for each `group_size` elements
-    and quantize every `group_size` elements with the same quantization parameter.
-    The dimension for scales/zero_points will be (M * ceil(N, group_size),)
-
-    Args:
-       input (torch.Tensor): quantized Tensor (uint8/int8 etc.)
-       scales (float32 torch.Tensor): quantization parameter for per channel group affine quantization
-       zero_points (int32 torch.Tensor): quantization parameter for per channel group affine quantization
-       quant_min (int): minimum quantized value for input Tensor
-       quant_max (int): maximum quantized value for input Tensor
-       dtype (torch.dtype): dtype (e.g. torch.uint8) for input Tensor
-       output_dtype (torch.dtype): dtype (e.g. torch.float32) for output Tensor
-
-    Returns:
-       dequantized Tensor with dtype `output_dtype`
-    """
-
-    assert group_size > 1
-    # needed for GPTQ single column dequantize
-    if group_size > w_int8.shape[-1] and scales.shape[-1] == 1:
-        group_size = w_int8.shape[-1]
-    assert w_int8.shape[-1] % group_size == 0
-    assert w_int8.dim() == 2
-
-    w_int8_grouped = w_int8.reshape(-1, group_size)
-    scales = scales.reshape(-1, 1)
-    zp = zero_points.reshape(-1, 1) if zero_points is not None else 0
-    w_dq = w_int8_grouped.sub(zp).mul(scales).reshape_as(w_int8).to(output_dtype)
-    return w_dq
+    quantized_decomposed_lib.define("unpack_int4_to_int8(Tensor int8_data) -> Tensor")
 
 
-def down_size(size):
-    assert size[-1] % 2 == 0, f"{size} last dim not divisible by two"
-    return (*size[:-1], size[-1] // 2)
+    @impl(quantized_decomposed_lib, "unpack_int4_to_int8", "CompositeExplicitAutograd")
+    def unpack_int4_to_int8(int8_data: torch.Tensor) -> torch.Tensor:
+        """Get the original weight from the normalized float weight format"""
+        # since we are using int8 we will decode 2 entries per byte
+        # Shift elements down 4 and select out the bottom 4 bits
+        shape = int8_data.shape
+        first_elements = (int8_data >> 4).to(torch.int8)
+        second_elements = (int8_data & 0b1111).to(torch.int8)
+        return torch.stack([first_elements, second_elements], dim=-1).view(up_size(shape))
 
 
-def up_size(size):
-    return (*size[:-1], size[-1] * 2)
+    def per_token_dynamic_quant(input: torch.Tensor) -> torch.Tensor:
+        orig_dtype = input.dtype
+        # TODO: we may need to make the choose_qparams op configurable
+        (
+            scales,
+            zero_points,
+        ) = torch.ops.quantized_decomposed.choose_qparams_per_token_asymmetric(
+            input, torch.int8
+        )
 
-
-quantized_decomposed_lib.define("pack_int4_from_int8(Tensor int8_data) -> Tensor")
-
-
-@impl(quantized_decomposed_lib, "pack_int4_from_int8", "CompositeExplicitAutograd")
-def pack_int4_from_int8(int8_data: torch.Tensor) -> torch.Tensor:
-    # converting to uint8 for operations
-    shape = int8_data.shape
-    assert shape[-1] % 2 == 0
-    int8_data = int8_data.contiguous().view(-1)
-    return (int8_data[::2] << 4 | int8_data[1::2]).view(down_size(shape))
-
-
-quantized_decomposed_lib.define("unpack_int4_to_int8(Tensor int8_data) -> Tensor")
-
-
-@impl(quantized_decomposed_lib, "unpack_int4_to_int8", "CompositeExplicitAutograd")
-def unpack_int4_to_int8(int8_data: torch.Tensor) -> torch.Tensor:
-    """Get the original weight from the normalized float weight format"""
-    # since we are using int8 we will decode 2 entries per byte
-    # Shift elements down 4 and select out the bottom 4 bits
-    shape = int8_data.shape
-    first_elements = (int8_data >> 4).to(torch.int8)
-    second_elements = (int8_data & 0b1111).to(torch.int8)
-    return torch.stack([first_elements, second_elements], dim=-1).view(up_size(shape))
-
-
-def per_token_dynamic_quant(input: torch.Tensor) -> torch.Tensor:
-    orig_dtype = input.dtype
-    # TODO: we may need to make the choose_qparams op configurable
-    (
-        scales,
-        zero_points,
-    ) = torch.ops.quantized_decomposed.choose_qparams_per_token_asymmetric(
-        input, torch.int8
-    )
-
-    # TODO: get these from torch.int8
-    quant_min = -128
-    quant_max = 127
-    input = torch.ops.quantized_decomposed.quantize_per_token(
-        input, scales, zero_points, quant_min, quant_max, torch.int8
-    )
-    input = torch.ops.quantized_decomposed.dequantize_per_token(
-        input, scales, zero_points, quant_min, quant_max, torch.int8, orig_dtype
-    )
-    return input
+        # TODO: get these from torch.int8
+        quant_min = -128
+        quant_max = 127
+        input = torch.ops.quantized_decomposed.quantize_per_token(
+            input, scales, zero_points, quant_min, quant_max, torch.int8
+        )
+        input = torch.ops.quantized_decomposed.dequantize_per_token(
+            input, scales, zero_points, quant_min, quant_max, torch.int8, orig_dtype
+        )
+        return input

--- a/torchao/quantization/utils.py
+++ b/torchao/quantization/utils.py
@@ -7,12 +7,14 @@ from typing import Dict, Optional
 
 import torch
 from torch.utils._python_dispatch import TorchDispatchMode
+from packaging import version
 
 __all__ = [
     "find_multiple",
     "compute_error",
     "_apply_logging_hook",
     "get_model_size_in_bytes",
+    "TORCH_VERSION_AFTER_2_4",
 ]
 
 
@@ -92,3 +94,9 @@ def get_model_size_in_bytes(model):
     for b in model.buffers():
         s += b.nelement() * b.element_size()
     return s
+
+
+if version.parse(torch.__version__) >= version.parse("2.4.0.dev"):
+    TORCH_VERSION_AFTER_2_4 = True
+else:
+    TORCH_VERSION_AFTER_2_4 = False


### PR DESCRIPTION
Summary:
since executorch is removing dep on torchao and only depend on pytorch for now, we need to move these ops to pytorch so they can have access we can move back when torchao is in a more mature state

Test Plan:
CI

Reviewers:

Subscribers:

Tasks:

Tags: