### PR TITLE
Fixing assert bug

### DIFF
--- a/torchao/kernel/intmm.py
+++ b/torchao/kernel/intmm.py
@@ -64,7 +64,7 @@ def int_scaled_matmul(a, b, scales1):
     assert M == scales1.size(0)
     assert 1 == scales1.size(1)
     assert scales1.is_contiguous()
-    assert scales1.dtype == torch.bfloat16
+
     scales1 = scales1.expand((M, N))
     assert scales1.dim() == 2
     if intmm_triton is not None and AUTOTUNER_ENABLE:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #88

Summary: we support handling fp32, fp16 and bf16 tensors with
quantization, asserting we only handle bf16 was breaking things.

Test Plan:

python test/test.py -k "test_int8_dynamic_quant_subclass"

Reviewers:

Subscribers:

Tasks:

Tags: