### PR TITLE
Use .to() instead of get_original_weight in linear_nf4 backward

### DIFF
--- a/torchao/dtypes/nf4tensor.py
+++ b/torchao/dtypes/nf4tensor.py
@@ -569,9 +569,9 @@ class LinearNF4(torch.autograd.Function):
     #  inconsistently.
 
     def backward(ctx, grad_output):
-        """The nf4 weight will never require grad so we can just return the grad_output @ weight.get_original_weight()"""
+        """The nf4 weight will never require grad so we can just return the grad_output @ weight.to(grad_output.dtype)"""
         weight: NF4Tensor = ctx.nf4_weight
-        return grad_output @ weight.get_original_weight(), None
+        return grad_output @ weight.to(grad_output.dtype), None
 
 
 def linear_nf4(input: torch.Tensor, weight: NF4Tensor) -> torch.Tensor:


### PR DESCRIPTION
- This will help ensure gradients are computed in the expected dtype and not coupled to bf16.
- This also helps with overall deprecation of `get_original_weight` by eliminating a callsite.