### PR TITLE
[be] Add SimpleFakeQuantize for QAT

### DIFF
--- a/test/quantization/test_qat_quant_api.py
+++ b/test/quantization/test_qat_quant_api.py
@@ -1,0 +1,88 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+# mypy: ignore-errors
+# This test takes a long time to run
+
+import copy
+import unittest
+
+import torch
+from torch.ao.quantization import (
+    FakeQuantize,
+    MinMaxObserver,
+    PerChannelMinMaxObserver,
+)
+from torchao.quantization._qat_quant_api import SimpleFakeQuantize
+
+
+class TestQATQuantAPI(unittest.TestCase):
+    SEED = 123
+
+    def test_simple_fake_quantize(self):
+        """
+        Test that `SimpleFakeQuantize` produces the exact same behavior as
+        `torch.ao.quantization.FakeQuantize` by default.
+        """
+        observer_ctr = MinMaxObserver.with_args(quant_min=0, quant_max=127)
+        old_fq = FakeQuantize(observer=observer_ctr)
+        simple_fq = SimpleFakeQuantize(observer=observer_ctr())
+
+        # Test numerics match exactly
+        torch.manual_seed(self.SEED)
+        x = torch.randn(100, 256)
+        x2 = copy.deepcopy(x)
+        y = old_fq(x)
+        y2 = simple_fq(x2)
+        torch.testing.assert_allclose(y, y2, rtol=0, atol=0)
+
+        # Test get observer attributes
+        self.assertEquals(simple_fq.quant_min, 0)
+        self.assertEquals(simple_fq.quant_max, 127)
+        self.assertEquals(simple_fq.qscheme, torch.per_tensor_affine)
+        self.assertEquals(simple_fq.is_dynamic, False)
+        self.assertEquals(simple_fq.eps, torch.finfo(torch.float32).eps)
+
+    def test_simple_fake_quantize_per_channel(self):
+        """
+        Test that `SimpleFakeQuantize` produces the exact same behavior as
+        `torch.ao.quantization.FakeQuantize` in the per channel case.
+        """
+
+        def _fake_quantize_per_channel_affine(x, scale, zp, qmin, qmax):
+            return torch.fake_quantize_per_channel_affine(x, scale, zp, 0, qmin, qmax)
+
+        observer_ctr = PerChannelMinMaxObserver.with_args(
+            ch_axis=0,
+            quant_min=0,
+            quant_max=127,
+            qscheme=torch.per_channel_affine,
+        )
+        old_fq = FakeQuantize(observer=observer_ctr)
+        simple_fq = SimpleFakeQuantize(
+            observer=observer_ctr(),
+            fake_quant_op=_fake_quantize_per_channel_affine,
+        )
+
+        # Test numerics match exactly
+        torch.manual_seed(self.SEED)
+        x = torch.randn(100, 256)
+        x2 = copy.deepcopy(x)
+        y = old_fq(x)
+        y2 = simple_fq(x2)
+        torch.testing.assert_allclose(y, y2, rtol=0, atol=0)
+
+        # Test get observer attributes
+        self.assertEquals(simple_fq.ch_axis, 0)
+        self.assertEquals(simple_fq.quant_min, 0)
+        self.assertEquals(simple_fq.quant_max, 127)
+        self.assertEquals(simple_fq.qscheme, torch.per_channel_affine)
+        self.assertEquals(simple_fq.is_dynamic, False)
+        self.assertEquals(simple_fq.eps, torch.finfo(torch.float32).eps)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchao/quantization/_qat_quant_api.py
+++ b/torchao/quantization/_qat_quant_api.py
@@ -1,0 +1,68 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Callable, Optional, Tuple
+
+import torch
+from torch.ao.quantization import (
+    FakeQuantizeBase,
+    ObserverBase,
+)
+
+
+class SimpleFakeQuantize(FakeQuantizeBase):
+    """
+    Thin wrapper module around an Observer instance and a fake quant op.
+
+    Args:
+        observer: Observer module instance
+        fake_quant_op: function with args (input, scale, zp, qmin, qmax),
+            defaulting to `torch.fake_quantize_per_tensor_affine`
+
+    TODO: This should capture most of the functionality in the existing
+    toq.FakeQuantize class, but is much simpler. In the future we should
+    consider deprecating toq.FakeQuantize in favor of this class
+    """
+
+    def __init__(
+        self,
+        observer: ObserverBase,
+        fake_quant_op: Optional[Callable] = None,
+    ):
+        super().__init__()
+        self.observer = observer
+        if fake_quant_op is not None:
+            self.fake_quant_op = fake_quant_op
+        else:
+            self.fake_quant_op = torch.fake_quantize_per_tensor_affine
+
+    def forward(self, x):
+        if self.observer_enabled[0] == 1:
+            self.observer(x.detach())
+            scale, zp = self.calculate_qparams()
+        if self.fake_quant_enabled[0] == 1:
+            qmin = self.observer.quant_min
+            qmax = self.observer.quant_max
+            x = self.fake_quant_op(
+                x, scale, zp, self.observer.quant_min, self.observer.quant_max,
+            )
+        return x
+
+    def calculate_qparams(self) -> Tuple[torch.Tensor, torch.Tensor]:
+        return self.observer.calculate_qparams()
+
+    def __getattr__(self, name):
+        """
+        Redirect getattr calls to observers for observer attributes.
+        """
+        observer_attrs = [
+            "ch_axis", "dtype", "qscheme", "quant_min", "quant_max",
+            "eps", "is_dynamic", "scale", "zero_point",
+        ]
+        if name in observer_attrs:
+            return getattr(self.observer, name)
+        else:
+            return super().__getattr__(name)


### PR DESCRIPTION
Summary: This commit adds a simpler version of toq.FakeQuantize to be used for various flavors of QAT. In the future we should deprecate toq.FakeQuantize in favor of this new class.

Test Plan:
python test/quantization/test_qat_quant_api.py

Reviewers: jerryzh168

Subscribers: jerryzh168, supriyar