### PR TITLE
add int4 gptq and eval

### DIFF
--- a/test/quantization/model.py
+++ b/test/quantization/model.py
@@ -10,15 +10,15 @@ import torch
 import torch.nn as nn
 from torch import Tensor
 from torch.nn import functional as F
+from torchao.quantization.utils import find_multiple
 
-def prepare_inputs_for_model(inps):
+def prepare_inputs_for_model(inps, max_new_tokens=1):
     # this is because input from lm-eval is 2d
-    if input.dim() != 2:
-        raise ValueError(f"Expected input to be of dim 2, but got {input.dim()}")
+    if inps.dim() != 2:
+        raise ValueError(f"Expected input to be of dim 2, but got {inps.dim()}")
 
     inps = inps.squeeze(0)
     # setup inputs in correct format
-    max_new_tokens = 1
     T = inps.size(0)
     T_new = T + max_new_tokens
     seq = torch.empty(T_new, dtype=inps.dtype, device=inps.device)
@@ -26,11 +26,6 @@ def prepare_inputs_for_model(inps):
     input_pos = torch.arange(0, T, device=inps.device)
     x = seq.index_select(0, input_pos).view(1, -1)
     return (x, input_pos)
-
-def find_multiple(n: int, k: int) -> int:
-    if n % k == 0:
-        return n
-    return n + k - (n % k)
 
 @dataclass
 class ModelArgs:

--- a/test/quantization/test_quant_api.py
+++ b/test/quantization/test_quant_api.py
@@ -151,8 +151,8 @@ class TestQuantFlow(unittest.TestCase):
         m(*example_inputs)
 
     @unittest.skip("skipping until we get checkpoints for gpt-fast")
-    def test_gptq_quantizer(self):
-        from torchao.quantization.GPTQ import Int8DynActInt4WeightGPTQQuantizer, InputRecorder
+    def test_8da4w_gptq_quantizer(self):
+        from torchao.quantization.GPTQ import Int8DynActInt4WeightGPTQQuantizer, InputRecorder, TransformerEvalWrapper
         # should be similar to TorchCompileDynamicQuantizer
         precision = torch.bfloat16
         device = "cpu"
@@ -161,6 +161,7 @@ class TestQuantFlow(unittest.TestCase):
         checkpoint = torch.load(str(checkpoint_path), mmap=True, weights_only=True)
         model.load_state_dict(checkpoint, assign=True)
         model = model.to(dtype=precision, device=device)
+        model.eval()
         tokenizer_path = checkpoint_path.parent / "tokenizer.model"
         assert tokenizer_path.is_file(), tokenizer_path
         tokenizer = SentencePieceProcessor(  # pyre-ignore[28]
@@ -190,12 +191,60 @@ class TestQuantFlow(unittest.TestCase):
             blocksize,
             percdamp,
             groupsize,
+            precision=precision,
         )
         model.setup_caches(max_batch_size=1, max_seq_length=calibration_seq_length)
         model = quantizer.quantize(model, inputs)
-        compiled = torch.compile(model, mode="max-autotune")
-        with torch.no_grad():
-            compiled(inputs[0].values[0], inputs[1].values[0])
+        result=TransformerEvalWrapper(
+            model,
+            tokenizer,
+            model.config.block_size,
+            prepare_inputs_for_model,
+            device,
+        ).run_eval(
+            ["wikitext"],
+            1,
+        )
+
+        assert result['results']['wikitext']['word_perplexity,none'] < 7.88, (
+            f"accuracy regressed from 7.87 to {result['results']['wikitext']['word_perplexity,none']}"
+        )
+
+    @unittest.skip("skipping until we get checkpoints for gpt-fast")
+    @unittest.skipIf(not TORCH_VERSION_AFTER_2_4, "skipping when torch verion is 2.4 or lower")
+    def test_8da4w_quantizer_eval(self):
+        from torchao.quantization.quant_api import Int8DynActInt4WeightQuantizer
+        from torchao.quantization.GPTQ import TransformerEvalWrapper
+
+        precision = torch.bfloat16
+        device = "cpu"
+        checkpoint_path = Path("../gpt-fast/checkpoints/meta-llama/Llama-2-7b-chat-hf/model.pth")
+        model = Transformer.from_name(checkpoint_path.parent.name)
+        checkpoint = torch.load(str(checkpoint_path), mmap=True, weights_only=True)
+        model.load_state_dict(checkpoint, assign=True)
+        model = model.to(dtype=precision, device=device)
+        model.eval()
+        tokenizer_path = checkpoint_path.parent / "tokenizer.model"
+        assert tokenizer_path.is_file(), tokenizer_path
+        tokenizer = SentencePieceProcessor(  # pyre-ignore[28]
+            model_file=str(tokenizer_path)
+        )
+
+        quantizer = Int8DynActInt4WeightQuantizer(groupsize=128, precision=precision)
+        q_model = quantizer.quantize(model)
+        result=TransformerEvalWrapper(
+            q_model,
+            tokenizer,
+            q_model.config.block_size,
+            prepare_inputs_for_model,
+            device,
+        ).run_eval(
+            ["wikitext"],
+            1,
+        )
+        assert result['results']['wikitext']['word_perplexity,none'] < 8.24, (
+            f"accuracy regressed from 8.23 to {result['results']['wikitext']['word_perplexity,none']}"
+        )
 
     @unittest.skip("skipping until we get checkpoints for gpt-fast")
     def test_gptq_quantizer_gpt_fast(self):
@@ -247,6 +296,96 @@ class TestQuantFlow(unittest.TestCase):
         compiled = torch.compile(model, mode="max-autotune")
         with torch.no_grad():
             compiled(inputs[0].values[0], inputs[1].values[0])
+
+    @unittest.skip("skipping until we get checkpoints for gpt-fast")
+    def test_gptq_quantizer_int4wo(self):
+        from torchao.quantization.GPTQ import Int4WeightOnlyGPTQQuantizer, InputRecorder, TransformerEvalWrapper
+        # should be similar to TorchCompileDynamicQuantizer
+        precision = torch.bfloat16
+        device = "cuda"
+        checkpoint_path = Path("../gpt-fast/checkpoints/meta-llama/Llama-2-7b-chat-hf/model.pth")
+        model = Transformer.from_name(checkpoint_path.parent.name)
+        checkpoint = torch.load(str(checkpoint_path), mmap=True, weights_only=True)
+        model.load_state_dict(checkpoint, assign=True)
+        model = model.to(dtype=precision, device="cpu")
+        model.eval()
+        tokenizer_path = checkpoint_path.parent / "tokenizer.model"
+        assert tokenizer_path.is_file(), tokenizer_path
+        tokenizer = SentencePieceProcessor(  # pyre-ignore[28]
+            model_file=str(tokenizer_path)
+        )
+        blocksize = 128
+        percdamp = 0.01
+        groupsize = 128
+        calibration_tasks = ["wikitext"]
+        calibration_limit = 1
+        calibration_seq_length = 100
+        input_prep_func = prepare_inputs_for_model
+        pad_calibration_inputs = False
+
+        inputs = InputRecorder(
+            tokenizer,
+            calibration_seq_length,
+            input_prep_func,
+            pad_calibration_inputs,
+            model.config.vocab_size,
+            device="cpu",
+        ).record_inputs(
+            calibration_tasks,
+            calibration_limit,
+        ).get_inputs()
+
+        quantizer = Int4WeightOnlyGPTQQuantizer(
+            blocksize,
+            percdamp,
+            groupsize,
+        )
+        model.setup_caches(max_batch_size=1, max_seq_length=calibration_seq_length)
+
+        model = quantizer.quantize(model, inputs).cuda()
+        result = TransformerEvalWrapper(
+            model.cuda(),
+            tokenizer,
+            model.config.block_size,
+            prepare_inputs_for_model,
+            device,
+        ).run_eval(
+            ["wikitext"],
+            1,
+        )
+        assert result['results']['wikitext']['word_perplexity,none'] < 7.77, (
+            f"accuracy regressed from 7.76 to {result['results']['wikitext']['word_perplexity,none']}"
+        )
+
+    @unittest.skip("skipping until we get checkpoints for gpt-fast")
+    def test_eval_wrapper(self):
+        from torchao.quantization.GPTQ import TransformerEvalWrapper
+        precision = torch.bfloat16
+        device = "cuda"
+        checkpoint_path = Path("../gpt-fast/checkpoints/meta-llama/Llama-2-7b-chat-hf/model.pth")
+        model = Transformer.from_name(checkpoint_path.parent.name)
+        checkpoint = torch.load(str(checkpoint_path), mmap=True, weights_only=True)
+        model.load_state_dict(checkpoint, assign=True)
+        model = model.to(dtype=precision, device=device)
+        model.eval()
+        tokenizer_path = checkpoint_path.parent / "tokenizer.model"
+        assert tokenizer_path.is_file(), tokenizer_path
+        tokenizer = SentencePieceProcessor(  # pyre-ignore[28]
+            model_file=str(tokenizer_path)
+        )
+        result=TransformerEvalWrapper(
+            model,
+            tokenizer,
+            model.config.block_size,
+            prepare_inputs_for_model,
+            device,
+        ).run_eval(
+            ["wikitext"],
+            1,
+        )
+        assert result['results']['wikitext']['word_perplexity,none']<7.77, (
+            f"accuracy regressed from 7.76 to {result['results']['wikitext']['word_perplexity,none']}"
+        )
 
 if __name__ == "__main__":
     unittest.main()

--- a/torchao/quantization/GPTQ.py
+++ b/torchao/quantization/GPTQ.py
@@ -20,12 +20,18 @@ import torch.nn.functional as F
 # from model import Transformer  # pyre-ignore[21]
 from torch.utils._pytree import tree_flatten, tree_unflatten
 
-from .utils import TORCH_VERSION_AFTER_2_3
-from typing import Any, Dict, Tuple, Optional
+from .utils import TORCH_VERSION_AFTER_2_3, find_multiple
+from typing import Any, Dict, Optional
 from .unified import Quantizer
-from functools import reduce
-from math import gcd
 
+
+from model import find_multiple
+from .quant_primitives import (
+    get_groupwise_affine_qparams,
+    groupwise_affine_quantize_tensor_from_qparams,
+    groupwise_affine_dequantize_tensor_from_qparams,
+    pack_tinygemm_scales_and_zeros,
+)
 aten = torch.ops.aten
 
 ## eval.py ##
@@ -50,6 +56,21 @@ if lm_eval_available:
         evaluate = evaluator.evaluate
 else:
     logging.info("lm_eval is not installed, GPTQ may not be usable")
+
+add_ons = []
+
+if lm_eval_available:
+    add_ons += ["InputRecorder", "TransformerEvalWrapper"]
+
+if TORCH_VERSION_AFTER_2_3:
+    add_ons += ["Int8DynActInt4WeightQuantizer", "Int8DynActInt4WeightGPTQQuantizer"]
+
+
+__all__ = [
+    "MultiInput",
+    "WeightOnlyInt4Linear",
+    "Int4WeightOnlyGPTQQuantizer",
+] + add_ons
 
 if lm_eval_available:
     class InputRecorder(eval_wrapper):
@@ -193,6 +214,61 @@ if lm_eval_available:
         def _model_generate(self, context, max_length, eos_token_id):
             raise Exception("unimplemented")
 
+    class TransformerEvalWrapper(InputRecorder):
+        """
+        A wrapper class for GPTFast, providing integration with the lm-evaluation-harness library.
+        """
+        def __init__(
+            self,
+            model,
+            tokenizer,
+            max_seq_length,
+            input_prep_func=None,
+            device="cuda"
+        ):
+            super().__init__(None, None)
+            self._model = model
+            self._tokenizer = tokenizer
+            self._device = torch.device(device)
+            self._max_seq_length = max_seq_length
+
+            # need to take inps and convert to corrent input
+            # for model
+            self.input_prep_func = (
+                input_prep_func if input_prep_func is not None
+                else lambda x: (x,)
+            )
+
+        def _model_call(self, inps):
+            # TODO: make batches work
+            input = self.input_prep_func(inps)
+
+            max_seq_length = min(inps.size(1), self.max_length)
+            with torch.device(self._device):
+                self._model.setup_caches(self.batch_size, max_seq_length)
+            logits = self._model(*input)
+            return logits
+
+        def _model_generate(self, context, max_length, eos_token_id):
+            raise Exception('unimplemented')
+
+        def run_eval(self, tasks, limit):
+            try:
+                lm_eval.tasks.initialize_tasks()
+            except:
+                pass
+
+            task_dict = get_task_dict(tasks)
+            print("Evaluating Model On: ", task_dict)
+            with torch.no_grad():
+                result = evaluate(
+                    self,
+                    task_dict,
+                    limit=limit,
+                )
+            for task, res in result["results"].items():
+                print(f"{task}: {res}")
+            return result
 
 class MultiInput:
 
@@ -290,7 +366,10 @@ class GenericGPTQRunner(fx.Interpreter):
         # note any final packing for storage should happen here
 
         # `act_fake_quant_func`
-        self.act_fake_quant_func = act_fake_quant_func # accepts [activation tensor], returns a fake-quantized activation tensor
+        if act_fake_quant_func is None:
+            self.act_fake_quant_func = lambda x: x
+        else:
+            self.act_fake_quant_func = act_fake_quant_func # accepts [activation tensor], returns a fake-quantized activation tensor
         return self
 
     def run(self):
@@ -314,7 +393,7 @@ class GenericGPTQRunner(fx.Interpreter):
             quantized_state_dict.pop(param_fqn)
         return quantized_state_dict
 
-    def call_function(self, target, args, kwargs, skip_quant=False):  # noqa: C901
+    def call_function(self, target, args, kwargs, already_quantized=False):  # noqa: C901
 
         def tensors_to_cuda(args):
             new_args = []
@@ -354,9 +433,11 @@ class GenericGPTQRunner(fx.Interpreter):
         quantize_linear = (
             (target == aten.linear.default)  # if its a linear
             and id(args[1]) in self.id_to_name  # and if we know the layer name
-            and not skip_quant  # and if we weren't told to skip quantization
+            # and we haven't already quantized this layer
+            and not already_quantized
             # and if the skip_layer_func doesn't say we should skip
             and not (self.skip_layer_func is not None and self.skip_layer_func(args[1]))
+
         )  # then we will quantize this linear layer/weight
 
         if quantize_linear:  # instantiate variables for GPTQ
@@ -371,8 +452,7 @@ class GenericGPTQRunner(fx.Interpreter):
                 quantize_linear
             ):  # calculate H instead of output (will run the linear eventually with updated weight)
                 x = cur_args[0].float()
-                if self.act_fake_quant_func is not None:
-                    x = self.act_fake_quant_func(x)
+                x = self.act_fake_quant_func(x)
                 shape = x.shape
                 n = 1 if len(shape) == 2 else shape[0]
                 H *= total_batches / (total_batches + n)
@@ -382,10 +462,13 @@ class GenericGPTQRunner(fx.Interpreter):
                 ).t().float()
                 H += x.matmul(x.t())
             else:
+                # weight has already been quantized but still need to apply
+                # activation quant for final calculation
+                if already_quantized:
+                    cur_args = (self.act_fake_quant_func(cur_args[0]), *cur_args[1:])
+
                 # get output if its not a linear
                 out = super().call_function(target, cur_args, cur_kwargs)
-                # if isinstance(out, torch.Tensor) and (out.isnan().max() or out.sum()==0 or out.isinf().max()):
-                #     breakpoint()
                 if isinstance(out, torch.Tensor):
                     outputs.append(out.cpu())
                 else:
@@ -412,12 +495,12 @@ class GenericGPTQRunner(fx.Interpreter):
 
             # run linear with new weight to get corrected output
             new_out = self.call_function(
-                target, (args[0], DQ, *args[2:]), kwargs, skip_quant=True
+                target, (args[0], DQ, *args[2:]), kwargs, already_quantized=True
             )
 
             if self.debug:
                 old_out = self.call_function(
-                    target, (args[0][:2], args[1], *args[2:]), kwargs, skip_quant=True
+                    target, (args[0][:2], args[1], *args[2:]), kwargs, already_quantized=True
                 )
 
                 def SQNR(x, y):
@@ -450,7 +533,7 @@ class GenericGPTQRunner(fx.Interpreter):
                 Q2 = self.quantize_func(W, qparams2)
                 DQ2 = self.dequantize_func(Q2, qparams2).to(W.dtype)
                 old_q_out = self.call_function(
-                    target, (args[0][:2], DQ2, *args[2:]), kwargs, skip_quant=True
+                    target, (args[0][:2], DQ2, *args[2:]), kwargs, already_quantized=True
                 )
 
                 print(
@@ -547,133 +630,293 @@ class GenericGPTQRunner(fx.Interpreter):
         return Q, DQ.to(orig_dtype), all_qparams
 
 
+class GPTQQuantizer(Quantizer):
+    """
+    This class implements a GPTQ Quantizer that can be used to apply GPTQ to a model in concert with the GenericGPTQRunner class.
+    Unlike the base Quantizer class, the user does not need to implement the create_quantized_state_dict, instead they have to reimplement
+    __init__ such that it defines the functions for the quantization mode. User is expected to reimplement convert_for_runtime.
+
+    The following functions (which must be defined in __init__) are used to define the quantization mode for both GPTQ and
+    create_quantized_state_dict. Here is a description of each function.
+
+    get_qparams_func:
+        A function that calculates the quantization qparams for an input tensor.
+        Args:
+            weight: A 2d weight tensor with non-integer dtype.
+        Returns:
+            qparams: it can have any format but will need to be handled by the other defined functions below.
+
+    quantize_func:
+        A function that applies quantization to an input tensor. It should be noted
+        that this function needs to be able to handle quantizing the entire weight tensor, a single group,
+        or a single column.
+        Args:
+            weight: A 2d weight tensor with non-integer dtype.
+            qparams: the output from get_qparams_func
+        Returns:
+            quantized_weight: A 2d quantized weight tensor (generally with an integer dtype)
+
+
+    dequantize_func:
+        A function that dequantizes an input quantized weight tensor. It should be noted
+        that this function needs to be able to handle dequantizing the entire weight tensor, a single group,
+        or a single column.
+        Args:
+            quantized_weight: A 2d quantized weight tensor (generally with an integer dtype)
+            qparams: the output from get_qparams_func
+        Returns:
+            weight: A 2d weight tensor with non-integer dtype.
+
+    act_fake_quant_func (optional):
+            A function that (dynamically) quantizes activation to input
+            Args:
+                input: input Tensor in f32/bf16/f16
+            Returns:
+                output: dynamically quantized and dequantized Tensor (with the same dtype as input)
+
+    combine_qparams_list_func:
+        A function that combines several qparams into one qparam.
+        Args:
+            qparams_list: a list of qparams objects, each obtained by calling get_qparams_func
+            on a single group from a weight tensor
+        Returns:
+            qparams: an object of the same format as the qparams above.
+
+    skip_layer_func:
+        A function that determines which linear layers should be skipped during GPTQ
+        Args:
+            weight: A 2d weight tensor with non-integer dtype.
+        Returns:
+            skip: boolean indicating whether layer should be skipped
+
+    make_names_and_values_dict_func:
+        A function that prepares the qparams and quantized_weight and creates a dictionary indicating how they
+        should be inserted into the state_dict. Generally any packing of the weight and qparams should be done here.
+        Args:
+            quantized_weight: A 2d quantized weight tensor (generally with an integer dtype)
+            qparams: the output from get_qparams_func
+        Returns:
+            names_and_values_dict: a dictionary mapping the name of the parameters of the quantized module to the
+            corresponding quantized weights and qparams.
+    """
+
+    def __init__(self):
+
+        assert self.get_qparams_func is not None
+
+        assert self.quantize_func is not None
+
+        assert self.dequantize_func is not None
+
+        assert self.combine_qparams_list_func is not None
+
+        #  `make_names_and_values_dict_func`.
+        assert self.make_names_and_values_dict_func is not None
+
+    @torch.no_grad()
+    def _create_quantized_state_dict(
+        self,
+        model,
+        inputs,
+        blocksize,
+        percdamp,
+        groupsize,
+        #  `typing.Dict[<key type>, <value type>]` to avoid runtime subscripting errors.
+    ) -> Dict:
+        print("Tracing model for GPTQ")
+        GPTQ_runner = GenericGPTQRunner(
+            model,
+            inputs,
+            blocksize,
+            percdamp,
+            groupsize,
+        ).configure_quantization_mode(
+            self.get_qparams_func,  # pyre-ignore[16]
+            self.quantize_func,  # pyre-ignore[16]
+            self.dequantize_func,  # pyre-ignore[16]
+            self.combine_qparams_list_func,  # pyre-ignore[16]
+            self.make_names_and_values_dict_func,  # pyre-ignore[16]
+            self.skip_layer_func,  # pyre-ignore[16]
+            self.act_fake_quant_func if hasattr(self, "act_fake_quant_func") else None,  # pyre-ignore[16]
+        )
+        print("Applying GPTQ to weights")
+        GPTQ_runner.run()
+        return GPTQ_runner.get_quantized_state_dict()
+
+    def _convert_for_runtime(self, model: torch.nn.Module) -> "nn.Module":
+        raise NotImplementedError("_convert_for_runtime not implemented")
+
+    @torch.no_grad()
+    def quantize(self, model: torch.nn.Module, inputs: List[MultiInput], **kwargs: Any) -> torch.nn.Module:
+        pass
+
+
+def linear_forward_int4(x, weight_int4pack, scales_and_zeros, out_features, groupsize):
+    origin_x_size = x.size()
+    x = x.reshape(-1, origin_x_size[-1])
+    c = torch.ops.aten._weight_int4pack_mm(x, weight_int4pack, groupsize, scales_and_zeros)
+    new_shape = origin_x_size[:-1] + (out_features,)
+    c = c.reshape(new_shape)
+    return c
+
+class WeightOnlyInt4Linear(torch.nn.Module):
+    __constants__ = ['in_features', 'out_features']
+    in_features: int
+    out_features: int
+    weight: torch.Tensor
+
+    def __init__(
+            self, in_features: int, out_features: int,
+            bias=False, device=None, dtype=None, groupsize: int = 128, inner_k_tiles: int = 8, use_cuda=True,
+    ) -> None:
+        super().__init__()
+        self.padding = _check_linear_int4_k(in_features, groupsize, inner_k_tiles)
+        if self.padding:
+            from model import find_multiple
+            self.origin_in_features = in_features
+            in_features = find_multiple(in_features, 1024)
+
+        self.in_features = in_features
+        self.out_features = out_features
+        assert not bias, "require bias=False"
+        self.groupsize = groupsize
+        self.inner_k_tiles = inner_k_tiles
+
+        assert out_features % 8 == 0, "require out_features % 8 == 0"
+        assert in_features % (inner_k_tiles * 16) == 0, "require in_features % (innerKTiles * 16) == 0"
+        if use_cuda:
+            self.register_buffer(
+                "weight",
+                torch.empty((out_features // 8, in_features // (inner_k_tiles * 16), 32, inner_k_tiles // 2), dtype=torch.int32)
+            )
+        else:
+            self.register_buffer(
+                "weight",
+                torch.empty((out_features, in_features // 2), dtype=torch.uint8)
+            )
+        self.register_buffer(
+            "scales_and_zeros",
+            torch.empty((in_features // groupsize, out_features, 2), dtype=torch.bfloat16)
+        )
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        input = input.to(torch.bfloat16)
+        if self.padding:
+            import torch.nn.functional as F
+            input = F.pad(input, pad=(0, self.in_features - self.origin_in_features))
+        return linear_forward_int4(
+            input,
+            self.weight, self.scales_and_zeros, self.out_features, self.groupsize
+        )
+
+
+def _check_linear_int4_k(k, groupsize = 1, inner_k_tiles = None):
+    k_divisible_by_groupsize = k % groupsize == 0
+    if inner_k_tiles is not None:
+        k_divisible_by_16_times_inner_k_tiles = k % (inner_k_tiles * 16) == 0
+        return k_divisible_by_groupsize and k_divisible_by_16_times_inner_k_tiles
+    return k_divisible_by_groupsize
+
+def replace_linear_int4(module, groupsize, inner_k_tiles, padding_allowed, use_cuda=True, skip_layer_func = None):
+
+    for name, child in module.named_children():
+        if isinstance(child, nn.Linear) and (skip_layer_func is None or not skip_layer_func(child.weight)):
+            if _check_linear_int4_k(child.in_features, groupsize, inner_k_tiles) or padding_allowed:
+                setattr(module, name, WeightOnlyInt4Linear(
+                    child.in_features, child.out_features, bias=False,
+                    groupsize=groupsize, inner_k_tiles=inner_k_tiles, use_cuda=use_cuda
+                ))
+        else:
+            replace_linear_int4(child, groupsize, inner_k_tiles, padding_allowed, use_cuda, skip_layer_func)
+
+class Int4WeightOnlyGPTQQuantizer(GPTQQuantizer):
+        def __init__(
+            self,
+            blocksize,
+            percdamp,
+            groupsize,
+            inner_k_tiles=8,
+            padding_allowed=True,
+        ):
+            self.blocksize = blocksize
+            self.percdamp = percdamp
+            self.groupsize = groupsize
+            self.inner_k_tiles = inner_k_tiles
+            self.padding_allowed = padding_allowed
+            self.act_fake_quant_func = None
+            n_bit = 4
+            self.get_qparams_func = lambda w: get_groupwise_affine_qparams(
+                w, n_bit, groupsize
+            )
+            self.quantize_func = lambda w, qparams: groupwise_affine_quantize_tensor_from_qparams(
+                w, qparams[0], qparams[1], n_bit, groupsize
+            )
+            self.dequantize_func = lambda q, qparams: groupwise_affine_dequantize_tensor_from_qparams(
+                q,
+                qparams[0],
+                qparams[1],
+                n_bit,
+                groupsize,
+            )
+            self.combine_qparams_list_func = lambda qparams_list: [
+                torch.cat(x, dim=1) for x in zip(*qparams_list)
+            ]
+            # skip unless padding_allowed=True or its correctly sized
+            self.skip_layer_func = lambda linear_weight: not (
+                _check_linear_int4_k(linear_weight.shape[-1], groupsize) or padding_allowed
+            )
+
+            # we need to do the padding here, both for q and the qparams if necessary
+
+            # TODO: this is the gpt-fast version, merge with the main version later
+            def make_names_and_values_dict_func(q, qparams):
+                k = q.shape[1]
+                new_k = find_multiple(k, 1024)
+                # how much we need to pad the weight
+                delta_k = new_k - q.shape[1]
+                q = q.to(torch.int32)
+                final_q = torch.ops.aten._convert_weight_to_int4pack(F.pad(q, pad=(0, delta_k)), inner_k_tiles)
+                scales = qparams[0].to(torch.bfloat16)
+                zeros = qparams[1].to(torch.bfloat16)
+                scales_and_zeros = pack_tinygemm_scales_and_zeros(scales, zeros)
+                # how many new groups we need for padded weight
+                delta_groups = new_k // groupsize - scales_and_zeros.shape[0]
+                final_s_and_z = F.pad(scales_and_zeros, pad=(0,0,0,0,0, delta_groups), value=1)
+                return {"weight": final_q, "scales_and_zeros": final_s_and_z}
+
+            self.make_names_and_values_dict_func = make_names_and_values_dict_func
+            super().__init__()
+
+        def _convert_for_runtime(self, model):
+            # TODO: temporary path for gpt-fast, will remove later
+            replace_linear_int4(
+                model,
+                self.groupsize,
+                self.inner_k_tiles,
+                self.padding_allowed,
+                skip_layer_func = self.skip_layer_func,
+            )
+            return model
+
+        def quantize(self, model: torch.nn.Module, inputs: List[MultiInput], **kwargs: Any) -> torch.nn.Module:
+            state_dict = self._create_quantized_state_dict(
+                model,
+                inputs,
+                self.blocksize,
+                self.percdamp,
+                self.groupsize,
+            )
+            model = self._convert_for_runtime(model)
+            model.load_state_dict(state_dict, strict=False)
+            return model
+
+
 if TORCH_VERSION_AFTER_2_3:
     from .quant_primitives import (
         get_group_qparams_symmetric,
         group_quantize_tensor_symmetric,
         per_token_dynamic_quant,
     )
-
-    class GPTQQuantizer(Quantizer):
-        """
-        This class implements a GPTQ Quantizer that can be used to apply GPTQ to a model in concert with the GenericGPTQRunner class.
-        Unlike the base Quantizer class, the user does not need to implement the create_quantized_state_dict, instead they have to reimplement
-        __init__ such that it defines the functions for the quantization mode. User is expected to reimplement convert_for_runtime.
-
-        The following functions (which must be defined in __init__) are used to define the quantization mode for both GPTQ and
-        create_quantized_state_dict. Here is a description of each function.
-
-        get_qparams_func:
-            A function that calculates the quantization qparams for an input tensor.
-            Args:
-                weight: A 2d weight tensor with non-integer dtype.
-            Returns:
-                qparams: it can have any format but will need to be handled by the other defined functions below.
-
-        quantize_func:
-            A function that applies quantization to an input tensor. It should be noted
-            that this function needs to be able to handle quantizing the entire weight tensor, a single group,
-            or a single column.
-            Args:
-                weight: A 2d weight tensor with non-integer dtype.
-                qparams: the output from get_qparams_func
-            Returns:
-                quantized_weight: A 2d quantized weight tensor (generally with an integer dtype)
-
-
-        dequantize_func:
-            A function that dequantizes an input quantized weight tensor. It should be noted
-            that this function needs to be able to handle dequantizing the entire weight tensor, a single group,
-            or a single column.
-            Args:
-                quantized_weight: A 2d quantized weight tensor (generally with an integer dtype)
-                qparams: the output from get_qparams_func
-            Returns:
-                weight: A 2d weight tensor with non-integer dtype.
-
-        act_fake_quant_func (optional):
-             A function that (dynamically) quantizes activation to input
-             Args:
-                 input: input Tensor in f32/bf16/f16
-             Returns:
-                 output: dynamically quantized and dequantized Tensor (with the same dtype as input)
-
-        combine_qparams_list_func:
-            A function that combines several qparams into one qparam.
-            Args:
-                qparams_list: a list of qparams objects, each obtained by calling get_qparams_func
-                on a single group from a weight tensor
-            Returns:
-                qparams: an object of the same format as the qparams above.
-
-        skip_layer_func:
-            A function that determines which linear layers should be skipped during GPTQ
-            Args:
-                weight: A 2d weight tensor with non-integer dtype.
-            Returns:
-                skip: boolean indicating whether layer should be skipped
-
-        make_names_and_values_dict_func:
-            A function that prepares the qparams and quantized_weight and creates a dictionary indicating how they
-            should be inserted into the state_dict. Generally any packing of the weight and qparams should be done here.
-            Args:
-                quantized_weight: A 2d quantized weight tensor (generally with an integer dtype)
-                qparams: the output from get_qparams_func
-            Returns:
-                names_and_values_dict: a dictionary mapping the name of the parameters of the quantized module to the
-                corresponding quantized weights and qparams.
-        """
-
-        def __init__(self):
-
-            assert self.get_qparams_func is not None
-
-            assert self.quantize_func is not None
-
-            assert self.dequantize_func is not None
-
-            assert self.combine_qparams_list_func is not None
-
-            #  `make_names_and_values_dict_func`.
-            assert self.make_names_and_values_dict_func is not None
-
-        @torch.no_grad()
-        def _create_quantized_state_dict(
-            self,
-            model,
-            inputs,
-            blocksize,
-            percdamp,
-            groupsize,
-            #  `typing.Dict[<key type>, <value type>]` to avoid runtime subscripting errors.
-        ) -> Dict:
-            print("Tracing model for GPTQ")
-            GPTQ_runner = GenericGPTQRunner(
-                model,
-                inputs,
-                blocksize,
-                percdamp,
-                groupsize,
-            ).configure_quantization_mode(
-                self.get_qparams_func,  # pyre-ignore[16]
-                self.quantize_func,  # pyre-ignore[16]
-                self.dequantize_func,  # pyre-ignore[16]
-                self.combine_qparams_list_func,  # pyre-ignore[16]
-                self.make_names_and_values_dict_func,  # pyre-ignore[16]
-                self.skip_layer_func,  # pyre-ignore[16]
-                self.act_fake_quant_func if hasattr(self, "act_fake_quant_func") else None,  # pyre-ignore[16]
-            )
-            print("Applying GPTQ to weights")
-            GPTQ_runner.run()
-            return GPTQ_runner.get_quantized_state_dict()
-
-        def _convert_for_runtime(self, model: torch.nn.Module) -> "nn.Module":
-            raise NotImplementedError("_convert_for_runtime not implemented")
-
-        @torch.no_grad()
-        def quantize(self, model: torch.nn.Module, inputs: List[MultiInput], **kwargs: Any) -> torch.nn.Module:
-            pass
-
 
     def linear_forward_8da4w(
         x,
@@ -713,58 +956,6 @@ if TORCH_VERSION_AFTER_2_3:
         # c = c.reshape(new_shape)
 
         return c
-
-
-    class WeightOnlyInt4Linear(torch.nn.Module):
-        __constants__ = ['in_features', 'out_features']
-        in_features: int
-        out_features: int
-        weight: torch.Tensor
-
-        def __init__(
-                self, in_features: int, out_features: int,
-                bias=True, device=None, dtype=None, groupsize: int = 128, inner_k_tiles: int = 8, use_cuda=True,
-        ) -> None:
-            super().__init__()
-            self.padding = _check_linear_int4_k(in_features, groupsize, inner_k_tiles)
-            if self.padding:
-                from model import find_multiple
-                self.origin_in_features = in_features
-                in_features = find_multiple(in_features, 1024)
-
-            self.in_features = in_features
-            self.out_features = out_features
-            assert not bias, "require bias=False"
-            self.groupsize = groupsize
-            self.inner_k_tiles = inner_k_tiles
-
-            assert out_features % 8 == 0, "require out_features % 8 == 0"
-            assert in_features % (inner_k_tiles * 16) == 0, "require in_features % (innerKTiles * 16) == 0"
-            if use_cuda:
-                self.register_buffer(
-                    "weight",
-                    torch.empty((out_features // 8, in_features // (inner_k_tiles * 16), 32, inner_k_tiles // 2), dtype=torch.int32)
-                )
-            else:
-                self.register_buffer(
-                    "weight",
-                    torch.empty((out_features, in_features // 2), dtype=torch.uint8)
-                )
-            self.register_buffer(
-                "scales_and_zeros",
-                torch.empty((in_features // groupsize, out_features, 2), dtype=torch.bfloat16)
-            )
-
-        def forward(self, input: torch.Tensor) -> torch.Tensor:
-            input = input.to(torch.bfloat16)
-            if self.padding:
-                import torch.nn.functional as F
-                input = F.pad(input, pad=(0, self.in_features - self.origin_in_features))
-            return linear_forward_int4(
-                input,
-                self.weight, self.scales_and_zeros, self.out_features, self.groupsize
-            )
-
 
     class Int8DynActInt4WeightLinear(torch.nn.Module):
         __constants__ = ["in_features", "out_features"]
@@ -847,62 +1038,6 @@ if TORCH_VERSION_AFTER_2_3:
             )
 
 
-    def find_multiple(n: int, *args: Tuple[int]) -> int:
-        k: int = reduce(lambda x, y: x * y // gcd(x, y), args + (1,))  # type: ignore[9]
-        if n % k == 0:
-            return n
-        return n + k - (n % k)
-
-    def _check_linear_int4_k(k, groupsize = 1, inner_k_tiles = None):
-        k_divisible_by_groupsize = k % groupsize == 0
-        if inner_k_tiles is not None:
-            k_divisible_by_16_times_inner_k_tiles = k % (inner_k_tiles * 16) == 0
-            return k_divisible_by_groupsize and k_divisible_by_16_times_inner_k_tiles
-        return k_divisible_by_groupsize
-
-    def _calc_padded_size_linear_int4(k, groupsize=1):
-        return find_multiple(k, groupsize)
-
-    def linear_forward_int4(x, weight_int4pack, scales_and_zeros, out_features, groupsize):
-        origin_x_size = x.size()
-        x = x.reshape(-1, origin_x_size[-1])
-        c = torch.ops.aten._weight_int4pack_mm(x, weight_int4pack, groupsize, scales_and_zeros)
-        new_shape = origin_x_size[:-1] + (out_features,)
-        c = c.reshape(new_shape)
-        return c
-
-    def pack_scales_and_zeros(scales, zeros, precision=torch.float32):
-        assert scales.shape == zeros.shape
-        assert scales.dtype == precision
-        assert zeros.dtype == precision
-        return (
-            torch.cat(
-                [
-                    scales.reshape(scales.size(0), scales.size(1), 1),
-                    zeros.reshape(zeros.size(0), zeros.size(1), 1),
-                ],
-                2,
-            )
-            .transpose(0, 1)
-            .contiguous()
-        )
-
-    def unpack_scales_and_zeros(scales_and_zeros):
-        assert len(scales_and_zeros.shape) == 3 and scales_and_zeros.shape[2] == 2
-        assert scales_and_zeros.dtype == torch.float
-        return torch.split(scales_and_zeros.transpose(0, 1), 1, 2)
-
-    def replace_linear_int4(module, groupsize, inner_k_tiles, padding_allowed, use_cuda):
-        for name, child in module.named_children():
-            if isinstance(child, nn.Linear):
-                if _check_linear_int4_k(child.in_features, groupsize, inner_k_tiles) or padding_allowed:
-                    setattr(module, name, WeightOnlyInt4Linear(
-                        child.in_features, child.out_features, bias=False,
-                        groupsize=groupsize, inner_k_tiles=inner_k_tiles, use_cuda=use_cuda
-                    ))
-            else:
-                replace_linear_int4(child, groupsize, inner_k_tiles, padding_allowed, use_cuda)
-
     def replace_linear_8da4w(
         module,
         groupsize,
@@ -933,23 +1068,6 @@ if TORCH_VERSION_AFTER_2_3:
                     precision,
                     scales_precision,
                 )
-
-    def pack_scales_and_zeros(scales, zeros):
-        assert scales.shape == zeros.shape
-        assert scales.dtype == torch.bfloat16
-        assert zeros.dtype == torch.bfloat16
-        return (
-            torch.cat(
-                [
-                    scales.reshape(scales.size(0), scales.size(1), 1),
-                    zeros.reshape(zeros.size(0), zeros.size(1), 1),
-                ],
-                2,
-            )
-            .transpose(0, 1)
-            .contiguous()
-        )
-
 
     class Int8DynActInt4WeightQuantizer(Quantizer):
         def __init__(
@@ -1019,7 +1137,7 @@ if TORCH_VERSION_AFTER_2_3:
                     )
                     if self._is_gpt_fast:
                         weight_int4pack = torch.ops.aten._convert_weight_to_int4pack(weight_int8.to(torch.int32), self.inner_k_tiles)
-                        scales_and_zeros = pack_scales_and_zeros(scales, zeros)
+                        scales_and_zeros = pack_tinygemm_scales_and_zeros(scales, zeros)
                         cur_state_dict[f"{fqn}.weight"] = weight_int4pack.to("cpu")
                         cur_state_dict[f"{fqn}.scales_and_zeros"] = scales_and_zeros.to("cpu")
                     else:
@@ -1058,27 +1176,6 @@ if TORCH_VERSION_AFTER_2_3:
             # TODO: make it strict
             model.load_state_dict(state_dict, strict=False)
             return model
-
-
-    # TODO: consolidate with other quantizers
-    class Int4WeightQuantizer(Quantizer):
-        def __init__(
-            self,
-            groupsize: int = 256,
-            padding_allowed: bool = False,
-            precision: torch.dtype = torch.float32,
-            inner_k_tiles: Optional[int] = None,
-            _use_cuda: bool = True,
-        ) -> None:
-            super().__init__(
-                groupsize,
-                padding_allowed,
-                precision,
-                torch.float32,  # scales_precision
-                inner_k_tiles,
-                True,  # _is_gpt_fast
-                _use_cuda,
-            )
 
 
     class Int8DynActInt4WeightGPTQQuantizer(GPTQQuantizer):
@@ -1146,7 +1243,7 @@ if TORCH_VERSION_AFTER_2_3:
                 final_q = torch.ops.aten._convert_weight_to_int4pack(F.pad(q, pad=(0, delta_k)), inner_k_tiles)
                 scales = qparams[0].to(torch.bfloat16)
                 zeros = qparams[1].to(torch.bfloat16)
-                scales_and_zeros = pack_scales_and_zeros(scales, zeros)
+                scales_and_zeros = pack_tinygemm_scales_and_zeros(scales, zeros)
                 # how many new groups we need for padded weight
                 delta_groups = new_k // groupsize - scales_and_zeros.shape[0]
                 final_s_and_z = F.pad(scales_and_zeros, pad=(0,0,0,0,0, delta_groups), value=1)
@@ -1154,7 +1251,7 @@ if TORCH_VERSION_AFTER_2_3:
 
             def make_names_and_values_dict_func(q, qparams):
                 k = q.shape[1]
-                new_k = _calc_padded_size_linear_int4(k, groupsize)
+                new_k = find_multiple(k, 1 if groupsize is None else groupsize)
                 # how much we need to pad the weight
                 delta_k = new_k - q.shape[1]
                 final_q = F.pad(q, pad=(0, delta_k))
@@ -1196,38 +1293,3 @@ if TORCH_VERSION_AFTER_2_3:
             model = self._convert_for_runtime(model)
             model.load_state_dict(state_dict, strict=False)
             return model
-
-
-    # TODO: consolidate with other quantizers
-    class Int4WeightGPTQQuantizer(Int8DynActInt4WeightGPTQQuantizer):
-
-        def __init__(
-            self,
-            tokenizer,
-            blocksize,
-            percdamp,
-            groupsize,
-            calibration_tasks,
-            calibration_limit,
-            calibration_seq_length,
-            pad_calibration_inputs,
-            inner_k_tiles=8,
-            padding_allowed=True,
-            precision=torch.float32,
-            _use_cuda=True,
-        ):
-            super().__init__(
-                tokenizer,
-                blocksize,
-                percdamp,
-                groupsize,
-                calibration_tasks,
-                calibration_limit,
-                calibration_seq_length,
-                pad_calibration_inputs,
-                inner_k_tiles=inner_k_tiles,
-                padding_allowed=padding_allowed,
-                precision=precision,
-                _is_gpt_fast=_is_gpt_fast,
-                _use_cuda=_use_cuda,
-            )

--- a/torchao/quantization/quant_api.py
+++ b/torchao/quantization/quant_api.py
@@ -30,6 +30,10 @@ from .subclass import (
 )
 from .weight_only import WeightOnlyInt8QuantLinear
 from .unified import Quantizer, TwoStepQuantizer
+from .GPTQ import (
+    Int4WeightOnlyGPTQQuantizer,
+)
+
 
 __all__ = [
     "apply_weight_only_int8_quant",
@@ -40,20 +44,19 @@ __all__ = [
     "swap_conv2d_1x1_to_linear",
     "Quantizer",
     "TwoStepQuantizer",
+    "Int4WeightOnlyGPTQQuantizer",
 ]
 
 if TORCH_VERSION_AFTER_2_3:
     from .GPTQ import (
         Int8DynActInt4WeightQuantizer,
         Int8DynActInt4WeightGPTQQuantizer,
-        Int4WeightQuantizer,
-        Int4WeightGPTQQuantizer,
+
     )
     __all__ += [
         "Int8DynActInt4WeightQuantizer",
         "Int8DynActInt4WeightGPTQQuantizer",
-        "Int4WeightQuantizer",
-        "Int4WeightGPTQQuantizer",
+
     ]
 
 

--- a/torchao/quantization/quant_primitives.py
+++ b/torchao/quantization/quant_primitives.py
@@ -500,23 +500,6 @@ def get_group_qparams_symmetric(w, n_bit=4, groupsize=128, precision=torch.float
     )
 
 
-def pack_scales_and_zeros(scales, zeros, precision=torch.float16):
-    assert scales.shape == zeros.shape
-    assert scales.dtype == precision
-    assert zeros.dtype == precision
-    return (
-        torch.cat(
-            [
-                scales.reshape(scales.size(0), scales.size(1), 1),
-                zeros.reshape(zeros.size(0), zeros.size(1), 1),
-            ],
-            2,
-        )
-        .transpose(0, 1)
-        .contiguous()
-    )
-
-
 if TORCH_VERSION_AFTER_2_3:
     def group_quantize_tensor_symmetric(
         w,
@@ -591,4 +574,4 @@ if TORCH_VERSION_AFTER_2_3:
         input = torch.ops.quantized_decomposed.dequantize_per_token(
             input, scales, zero_points, quant_min, quant_max, torch.int8, orig_dtype
         )
-        return input
+        return input.to(orig_dtype)

--- a/torchao/quantization/utils.py
+++ b/torchao/quantization/utils.py
@@ -3,11 +3,14 @@
 
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 
 import torch
 from torch.utils._python_dispatch import TorchDispatchMode
 from packaging import version
+from functools import reduce
+from math import gcd
+
 
 __all__ = [
     "find_multiple",
@@ -18,7 +21,8 @@ __all__ = [
 ]
 
 
-def find_multiple(n: int, k: int) -> int:
+def find_multiple(n: int, *args: Tuple[int]) -> int:
+    k: int = reduce(lambda x, y: x * y // gcd(x, y), args + (1,))  # type: ignore[9]
     if n % k == 0:
         return n
     return n + k - (n % k)


### PR DESCRIPTION
Summary: adding int4 gptq and eval support. Also fixed a few bugs relating to quantizing the activation both during gptq calculation and when calculating the output.

Test Plan: python test/quantization/test_quant_api.py

Reviewers:

Subscribers:

Tasks:

Tags:

ghstack-source-id: d29b6d73c90dec5171e12938afee25e5f42e042d
Pull Request resolved: https://github.com/pytorch-labs/ao/pull/115