### PR TITLE
Support int_scaled_mm on CPU

### DIFF
--- a/test/kernel/test_autotuner.py
+++ b/test/kernel/test_autotuner.py
@@ -52,13 +52,15 @@ class TestQuantFlow(unittest.TestCase):
     @parameterized.expand(
         [
             ("cuda", torch.bfloat16),
-            # TODO: ("cpu", torch.bfloat16),
+            ("cpu", torch.bfloat16),
             ("cuda", torch.float16),
-            # TODO: ("cpu", torch.float16),
+            ("cpu", torch.float16),
         ]
     )
-    @unittest.skipIf(not torch.cuda.is_available(), "Need CUDA available")
     def test_int_scaled_mm(self, device, dtype):
+        if device == "cuda" and not torch.cuda.is_available():
+            return
+
         from torchao.kernel import intmm
 
         dtype = torch.bfloat16

--- a/test/kernel/test_autotuner.py
+++ b/test/kernel/test_autotuner.py
@@ -59,7 +59,7 @@ class TestQuantFlow(unittest.TestCase):
     )
     def test_int_scaled_mm(self, device, dtype):
         if device == "cuda" and not torch.cuda.is_available():
-            return
+            self.skipTest(f"{device} not available")
 
         from torchao.kernel import intmm
 

--- a/torchao/kernel/intmm_triton.py
+++ b/torchao/kernel/intmm_triton.py
@@ -356,3 +356,9 @@ def int_scaled_matmul_cuda(a, b, scales1):
         int_scaled_matmul_kernel, [a, b, scales1, c], int8_mm_kernel_configs
     )
     return int_scaled_matmul_kernel(a, b, scales1, c, best_config)
+
+
+@torch.library.impl(lib, "int_scaled_matmul", "CPU")
+def int_scaled_matmul_cpu(a, b, scales1):
+    c = torch._int_mm(a, b)
+    return c.to(scales1.dtype) * scales1


### PR DESCRIPTION
**Description**
`int_scaled_mm` is supported on CUDA only now. This PRs adds support for CPU.
The op is implemented by `torch._int_mm`, whose CPU version has been added to PyTorch recently by https://github.com/pytorch/pytorch/issues/121792.
With this patch, SmoothQuant can go with `int_scaled_mm` on CPU with Inductor.
Example code:
```python
import torch
from torchao.quantization.smoothquant import swap_linear_with_smooth_fq_linear, smooth_fq_linear_to_inference
# convert linear modules to smoothquant
# linear module in calibration mode
swap_linear_with_smooth_fq_linear(model)
model.train()
# Calibrate the model
for data in dataset:
    model(*data)
# set it to inference mode
smooth_fq_linear_to_inference(model.eval())
with torch.no_grad():
    optimized_model = torch.compile(model)
    _ = optimized_model(*example_inputs)
    _ = optimized_model(*example_inputs)
```
Run with `TORCHAO_AUTOTUNER_ENABLE=1` and the following is found in the generated code:
```cpp
auto buf3 = op_torchao_int_scaled_matmul_.call(reinterpret_tensor(buf1, {16L, 1024L}, {1024L, 1L}, 0L), _frozen_param3, reinterpret_tensor(buf2, {16L, 1024L}, {1L, 0L}, 0L));
```

**Test plan**
python test/kernel/test_autotuner.py -k test_int_scaled_mm