### PR TITLE
Support `model.to` int8 weight only quantized model

### DIFF
--- a/torchao/quantization/weight_only.py
+++ b/torchao/quantization/weight_only.py
@@ -22,9 +22,8 @@ class WeightOnlyInt8QuantLinear(torch.nn.Linear):
         scales = kwargs.pop("scales")
         super().__init__(*args, **kwargs)
 
-        self.w_int8 = w_int8
-
-        self.scales = scales
+        self.register_buffer("w_int8", w_int8)
+        self.register_buffer("scales", scales)
 
     def forward(self, x, *args, **kwargs):
         """


### PR DESCRIPTION
Summary:
registering fields as buffers so they get picked up in `model.to`

Test Plan:
python test/quantization/test_quant_api.py -k test_int8_wo_quant_save_load Reviewers:

Subscribers:

Tasks:

Tags: